### PR TITLE
Allow a representation to be passed and make mimetype optional

### DIFF
--- a/packages/actor-init-ldes-client/README.md
+++ b/packages/actor-init-ldes-client/README.md
@@ -45,7 +45,9 @@ const newEngine = require('@treecg/actor-init-ldes-client').newEngine;
 const LDESClient = new newEngine();
 ```
 
-With the engine or client created, you can now use it to call te async ```createReadStream(url, options)``` method.
+With the engine or client created, you can now use it to call the async ```createReadStream(url, options)``` method.
+Note that next to retrieving a serialized string (`mimeType` option) of member data, an `Object` (JSON-LD) or `Quads` representation is also possible with the Javascript API using the `representation` option. 
+ 
 Here is an example synchronizing with a TREE root node of an Event Stream with polling interval of 5 seconds:
 
 ```javascript
@@ -74,9 +76,20 @@ try {
     };
     let LDESClient = new newEngine();
     let eventstreamSync = LDESClient.createReadStream(url, options);
-    eventstreamSync.on('data', (data) => {
-        let obj = JSON.parse(data);
-        console.log(obj);
+    eventstreamSync.on('data', (member) => {
+        if (options.representation) {
+            const memberURI = member.id;
+            console.log(memberURI);
+            if (options.representation === "Object") {
+                const object = member.object;
+                console.log(object);
+            } else if (options.representation === "Quads") {
+                const quads = member.quads;
+                console.log(quads);
+            }
+        } else {
+            console.log(member);
+        }
     });
     eventstreamSync.on('end', () => {
         console.log("No more data!");

--- a/packages/actor-init-ldes-client/README.md
+++ b/packages/actor-init-ldes-client/README.md
@@ -50,42 +50,38 @@ Here is an example synchronizing with a TREE root node of an Event Stream with p
 
 ```javascript
 import { newEngine } from '@treecg/actor-init-ldes-client';
- main()
- 
- function main() {
-     try {
-         let url = "https://apidg.gent.be/opendata/adlib2eventstream/v1/dmg/objecten";
-         let options = {
-             "pollingInterval": 5000, // millis
-             "mimeType": "application/ld+json",
-             "fromTime": new Date("2021-02-03T15:46:12.307Z"),
-             "emitMemberOnce": true,
-             "disablePolling": true,
-             "jsonLdContext": {
-                 "@context": [
-                     "https://apidg.gent.be/opendata/adlib2eventstream/v1/context/cultureel-erfgoed-object-ap.jsonld",
-                     "https://apidg.gent.be/opendata/adlib2eventstream/v1/context/persoon-basis.jsonld",
-                     "https://apidg.gent.be/opendata/adlib2eventstream/v1/context/cultureel-erfgoed-event-ap.jsonld",
-                     {
-                         "dcterms:isVersionOf": {
-                             "@type": "@id"
-                         },
-                         "prov": "http://www.w3.org/ns/prov#"
-                     }
-                 ]
-             }
-         };
-         let LDESClient = new newEngine();
-         let eventstreamSync = LDESClient.createReadStream(url, options);
-         eventstreamSync.on('data', (data) => {
-             let obj = JSON.parse(data);
-             console.log(obj);
-         });
-         eventstreamSync.on('end', () => {
-             console.log("No more data!");
-         });
-     } catch (e) {
-         console.error(e);
-     }
- }
+try {
+    let url = "https://apidg.gent.be/opendata/adlib2eventstream/v1/dmg/objecten";
+    let options = {
+        "pollingInterval": 5000, // millis
+        "representation": "Object", //Object or Quads
+        "fromTime": new Date("2021-02-03T15:46:12.307Z"),
+        "emitMemberOnce": true,
+        "disablePolling": true,
+        "jsonLdContext": { //Only necessary for Object representation
+            "@context": [
+                "https://apidg.gent.be/opendata/adlib2eventstream/v1/context/cultureel-erfgoed-object-ap.jsonld",
+                "https://apidg.gent.be/opendata/adlib2eventstream/v1/context/persoon-basis.jsonld",
+                "https://apidg.gent.be/opendata/adlib2eventstream/v1/context/cultureel-erfgoed-event-ap.jsonld",
+                {
+                     "dcterms:isVersionOf": {
+                         "@type": "@id"
+                    },
+                    "prov": "http://www.w3.org/ns/prov#"
+                }
+            ]
+        }
+    };
+    let LDESClient = new newEngine();
+    let eventstreamSync = LDESClient.createReadStream(url, options);
+    eventstreamSync.on('data', (data) => {
+        let obj = JSON.parse(data);
+        console.log(obj);
+    });
+    eventstreamSync.on('end', () => {
+        console.log("No more data!");
+    });
+} catch (e) {
+    console.error(e);
+}
 ```

--- a/packages/actor-init-ldes-client/lib/EventStream.ts
+++ b/packages/actor-init-ldes-client/lib/EventStream.ts
@@ -1,4 +1,5 @@
 import { Actor, IActorTest, Mediator } from "@comunica/core";
+import { Quad, NamedNode } from "@rdfjs/types";
 import type {
     IActionRdfMetadataExtract,
     IActorRdfMetadataExtractOutput,
@@ -222,7 +223,7 @@ export class EventStream extends Readable {
 
             const memberUris: string[] = this.getMemberUris(treeMetadata);
             const members = this.getMembers(quadsArrayOfPage, memberUris);
-
+            
             await this.processMembers(members);
         } catch (e) {
             this.log('error', `Failed to retrieve ${pageUrl}`, e);
@@ -326,7 +327,14 @@ export class EventStream extends Readable {
                             jsonLdContext: this.jsonLdContext
                         })).data);
                     } else {
-                        this.push(quadStream);
+                        //Build an array from the quads iterator
+                        let quadArray : Array<Quad> = [];
+                        quadStream.forEach((item) => {
+                            quadArray.push(item); 
+                        });
+                        quadStream.on('end', () => {
+                            this.push({ "@id": member.uri, quads: quadArray});
+                        });
                     }
                 } else {
                     let outputString;

--- a/packages/actor-init-ldes-client/lib/EventStream.ts
+++ b/packages/actor-init-ldes-client/lib/EventStream.ts
@@ -321,11 +321,13 @@ export class EventStream extends Readable {
                 if (this.representation) {
                     //Can be "Object" or "Quads"
                     if (this.representation === 'Object') {
-                        this.push((await this.mediators.mediatorRdfFrame.mediate({
+                        let framedResult = (await this.mediators.mediatorRdfFrame.mediate({
                             data: quadStream,
                             frames: [{"@id": id}],
                             jsonLdContext: this.jsonLdContext
-                        })).data);
+                        })).data;
+                        let firstEntry = framedResult.entries().next();
+                        this.push({ "id": firstEntry.value[0]["@id"], object: firstEntry.value[1]});
                     } else {
                         //Build an array from the quads iterator
                         let quadArray : Array<Quad> = [];
@@ -333,7 +335,7 @@ export class EventStream extends Readable {
                             quadArray.push(item); 
                         });
                         quadStream.on('end', () => {
-                            this.push({ "@id": member.uri, quads: quadArray});
+                            this.push({ "id": member.uri, quads: quadArray});
                         });
                     }
                 } else {

--- a/packages/actor-init-ldes-client/lib/LDESClient.ts
+++ b/packages/actor-init-ldes-client/lib/LDESClient.ts
@@ -33,7 +33,7 @@ export class LDESClient extends ActorInit implements ILDESClientArgs {
 
   Options:
     --pollingInterval            Number of milliseconds before refetching uncacheable fragments (e.g., 5000)
-    --mimeType                   the MIME type of the output (e.g., application/ld+json)
+    --mimeType                   the MIME type of the output (application/ld+json or text/turtle)
     --context                    path to a file with the JSON-LD context you want to use when MIME type is application/ld+json (e.g., ./context.jsonld)
     --disablePolling             whether to disable polling or not (by default set to "false", polling is enabled). Value can be set to "true" or "false"
     --fromTime                   datetime to prune relations that have a lower datetime value (e.g., 2020-01-01T00:00:00)
@@ -60,6 +60,7 @@ export class LDESClient extends ActorInit implements ILDESClientArgs {
 
     public pollingInterval: number;
     public mimeType: string;
+    public representation: string;
     public jsonLdContextPath: string;
     public jsonLdContextString: string;
     public emitMemberOnce: boolean;
@@ -104,7 +105,7 @@ export class LDESClient extends ActorInit implements ILDESClientArgs {
             } else {
                 options.emitMemberOnce = args.emitMemberOnce.toLowerCase() == 'true' ? true : false;
             }
-        } 
+        }
 
         if (args.disablePolling) {
             if (typeof args.disablePolling == "boolean") {
@@ -135,7 +136,10 @@ export class LDESClient extends ActorInit implements ILDESClientArgs {
         if (!options.pollingInterval) {
             options.pollingInterval = this.pollingInterval;
         }
-        if (!options.mimeType) {
+        //If mimetype is set: output serialized string
+        //If mimetype isn’t set, use the in-mem representation if it is set
+        //If the representation isn’t set, then just fall back to the standard mimetype
+        if (!options.mimeType && !options.representation) {
             options.mimeType = this.mimeType;
         }
         if (!options.jsonLdContext) {

--- a/packages/actor-init-ldes-client/test/LDESLibrary-test.ts
+++ b/packages/actor-init-ldes-client/test/LDESLibrary-test.ts
@@ -38,7 +38,7 @@ describe('LDESClient as a lib', () => {
         }
     });
 
-    test('Stream should emit Maps when configured with Object', (done) => {
+    test('Stream should emit Object when configured with Object', (done) => {
         try {
             let url = "https://semiceu.github.io/LinkedDataEventStreams/example.ttl";
             let options = {
@@ -47,7 +47,7 @@ describe('LDESClient as a lib', () => {
             let LDESClient = newEngine();
             let eventstreamSync = LDESClient.createReadStream(url, options);
             eventstreamSync.once('data', (member) => {
-                expect(member).toBeInstanceOf(Map);
+                expect(member.object).toBeInstanceOf(Object);
                 done();
             });
         } catch (e) {

--- a/packages/actor-init-ldes-client/test/LDESLibrary-test.ts
+++ b/packages/actor-init-ldes-client/test/LDESLibrary-test.ts
@@ -1,0 +1,57 @@
+import { newEngine } from '@treecg/actor-init-ldes-client';
+import { Quad } from "@rdfjs/types";
+
+
+
+describe('LDESClient as a lib', () => {
+    var LDESClient = newEngine();
+    test('Stream should emit strings when configured that way', (done) => {
+        try {
+            let url = "https://semiceu.github.io/LinkedDataEventStreams/example.ttl";
+            let options = {
+                "mimeType": "text/turtle"
+            };
+            let eventstreamSync = LDESClient.createReadStream(url, options);
+            eventstreamSync.once('data', (data) => {
+                expect(data).toBeDefined();
+                done();
+            });
+        } catch (e) {
+            done(e);
+        }
+    });
+
+    test('Stream should emit quads when configured that way', (done) => {
+        try {
+            let url = "https://semiceu.github.io/LinkedDataEventStreams/example.ttl";
+            let options = {
+                "representation": "Quads"
+            };
+            let LDESClient = newEngine();
+            let eventstreamSync = LDESClient.createReadStream(url, options);
+            eventstreamSync.once('data', (member) => {
+                expect(member.quads).toBeInstanceOf(Array);
+                done();
+            });
+        } catch (e) {
+            done(e);
+        }
+    });
+
+    test('Stream should emit Maps when configured with Object', (done) => {
+        try {
+            let url = "https://semiceu.github.io/LinkedDataEventStreams/example.ttl";
+            let options = {
+                "representation": "Object"
+            };
+            let LDESClient = newEngine();
+            let eventstreamSync = LDESClient.createReadStream(url, options);
+            eventstreamSync.once('data', (member) => {
+                expect(member).toBeInstanceOf(Map);
+                done();
+            });
+        } catch (e) {
+            done(e);
+        }
+    });
+});


### PR DESCRIPTION
The representation indicates whether an array of quads should be returned, or a JSON-LD framed object

The representation string can be: Quads or Object