### PR TITLE
Take advantage of Node's built-in streaming backpressure

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,3 @@
+[*.ts]
+indent_style = space
+indent_size = 4

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
       ],
       "dependencies": {
         "componentsjs-generator": "^3.1.0",
-        "exponential-backoff": "^3.1.1",
         "lerna": "^6.5.1",
         "typescript": "^5.0.2"
       },
@@ -15102,6 +15101,7 @@
         "@treecg/bus-rdf-frame": "^4.0.0",
         "@treecg/types": "^0.4.0",
         "content-type": "^1.0.5",
+        "exponential-backoff": "^3.1.1",
         "http-cache-semantics": "^4.1.1",
         "js-priority-queue": "^0.1.5",
         "lru-cache": "^8.0.4",
@@ -19066,8 +19066,7 @@
     "@octokit/plugin-request-log": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.4.tgz",
-      "integrity": "sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA==",
-      "requires": {}
+      "integrity": "sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA=="
     },
     "@octokit/plugin-rest-endpoint-methods": {
       "version": "6.8.1",
@@ -19220,6 +19219,7 @@
         "@types/http-cache-semantics": "^4.0.1",
         "@types/streamify-string": "^1.0.0",
         "content-type": "^1.0.5",
+        "exponential-backoff": "^3.1.1",
         "http-cache-semantics": "^4.1.1",
         "js-priority-queue": "^0.1.5",
         "lru-cache": "^8.0.4",
@@ -19776,22 +19776,19 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-2.1.0.tgz",
       "integrity": "sha512-K/vuv72vpfSEZoo5KIU0a2FsEoYdW0DUMtMpB5X3LlUwshetMZRZRxB7sCsVji/lFaSxtQQ3aM9O4eMolXkU9w==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@webpack-cli/info": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-2.0.1.tgz",
       "integrity": "sha512-fE1UEWTwsAxRhrJNikE7v4EotYflkEhBL7EbajfkPlf6E37/2QshOy/D48Mw8G5XMFlQtS6YV42vtbG9zBpIQA==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@webpack-cli/serve": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-2.0.4.tgz",
       "integrity": "sha512-0xRgjgDLdz6G7+vvDLlaRpFatJaJ69uTalZLRSMX5B3VUrDmXcrVA3+6fXXQgmYz7bY9AAgs348XQdmtLsK41A==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@xtuc/ieee754": {
       "version": "1.2.0",
@@ -19863,8 +19860,7 @@
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.9.0.tgz",
       "integrity": "sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "add-stream": {
       "version": "1.0.0",
@@ -19914,8 +19910,7 @@
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
       "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "ansi-colors": {
       "version": "4.1.3",
@@ -22541,8 +22536,7 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
       "integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "jest-rdf": {
       "version": "1.8.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
       ],
       "dependencies": {
         "componentsjs-generator": "^3.1.0",
+        "exponential-backoff": "^3.1.1",
         "lerna": "^6.5.1",
         "typescript": "^5.0.2"
       },
@@ -7350,6 +7351,11 @@
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
+    },
+    "node_modules/exponential-backoff": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.1.tgz",
+      "integrity": "sha512-dX7e/LHVJ6W3DE1MHWi9S1EYzDESENfLrYohG2G++ovZrYOkm4Knwa0mc1cn84xJOR4KEU0WSchhLbd0UklbHw=="
     },
     "node_modules/external-editor": {
       "version": "3.1.0",
@@ -21280,6 +21286,11 @@
         "jest-message-util": "^29.5.0",
         "jest-util": "^29.5.0"
       }
+    },
+    "exponential-backoff": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.1.tgz",
+      "integrity": "sha512-dX7e/LHVJ6W3DE1MHWi9S1EYzDESENfLrYohG2G++ovZrYOkm4Knwa0mc1cn84xJOR4KEU0WSchhLbd0UklbHw=="
     },
     "external-editor": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,6 @@
   "homepage": "https://github.com/TREEcg/event-stream-client#readme",
   "dependencies": {
     "componentsjs-generator": "^3.1.0",
-    "exponential-backoff": "^3.1.1",
     "lerna": "^6.5.1",
     "typescript": "^5.0.2"
   },

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
   "homepage": "https://github.com/TREEcg/event-stream-client#readme",
   "dependencies": {
     "componentsjs-generator": "^3.1.0",
+    "exponential-backoff": "^3.1.1",
     "lerna": "^6.5.1",
     "typescript": "^5.0.2"
   },

--- a/packages/actor-init-ldes-client/lib/Bookkeeper.ts
+++ b/packages/actor-init-ldes-client/lib/Bookkeeper.ts
@@ -84,7 +84,7 @@ export class Bookkeeper {
     }
 }
 
-interface FragmentInfo {
+export interface FragmentInfo {
     url: string;
     refetchTime: Date;
 }

--- a/packages/actor-init-ldes-client/package-lock.json
+++ b/packages/actor-init-ldes-client/package-lock.json
@@ -1,0 +1,4162 @@
+{
+  "name": "@treecg/actor-init-ldes-client",
+  "version": "4.0.9",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@treecg/actor-init-ldes-client",
+      "version": "4.0.9",
+      "license": "MIT",
+      "dependencies": {
+        "@comunica/actor-dereference-rdf-parse": "^2.6.8",
+        "@comunica/actor-http-fetch": "^2.6.8",
+        "@comunica/actor-http-proxy": "^2.6.8",
+        "@comunica/actor-rdf-parse-jsonld": "^2.6.8",
+        "@comunica/actor-rdf-parse-n3": "^2.6.8",
+        "@comunica/bus-dereference": "^2.6.8",
+        "@comunica/bus-http": "^2.6.8",
+        "@comunica/bus-init": "^2.6.8",
+        "@comunica/bus-rdf-metadata-extract": "^2.6.8",
+        "@comunica/bus-rdf-parse": "^2.6.8",
+        "@comunica/core": "^2.6.8",
+        "@comunica/mediator-combine-union": "^2.6.8",
+        "@comunica/mediator-number": "^2.6.8",
+        "@comunica/mediator-race": "^2.6.8",
+        "@comunica/query-sparql": "^2.6.8",
+        "@comunica/runner": "^2.6.8",
+        "@comunica/runner-cli": "^2.6.8",
+        "@treecg/actor-rdf-frame-with-json-ld-js": "^4.0.0",
+        "@treecg/actor-rdf-metadata-extract-tree": "^2.0.0",
+        "@treecg/bus-rdf-filter-object": "^4.0.0",
+        "@treecg/bus-rdf-frame": "^4.0.0",
+        "@treecg/types": "^0.4.0",
+        "content-type": "^1.0.5",
+        "exponential-backoff": "^3.1.1",
+        "http-cache-semantics": "^4.1.1",
+        "js-priority-queue": "^0.1.5",
+        "lru-cache": "^8.0.4",
+        "moment": "^2.29.4",
+        "n3": "^1.16.3",
+        "rdf-dereference": "^2.1.0",
+        "rdf-string": "^1.6.3"
+      },
+      "bin": {
+        "actor-init-ldes-client": "bin/run.js"
+      },
+      "devDependencies": {
+        "@types/content-type": "^1.1.5",
+        "@types/http-cache-semantics": "^4.0.1",
+        "@types/streamify-string": "^1.0.0"
+      }
+    },
+    "node_modules/@bergos/jsonparse": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@bergos/jsonparse/-/jsonparse-1.4.1.tgz",
+      "integrity": "sha512-vXIT0nzZGX/+yMD5bx2VhTzc92H55tPoehh1BW/FZHOndWGFddrH3MAfdx39FRc7irABirW6EQaGxIJYV6CGuA==",
+      "engines": [
+        "node >= 0.2.0"
+      ],
+      "dependencies": {
+        "buffer": "^6.0.3"
+      }
+    },
+    "node_modules/@colors/colors": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.6.0.tgz",
+      "integrity": "sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==",
+      "engines": {
+        "node": ">=0.1.90"
+      }
+    },
+    "node_modules/@comunica/actor-abstract-mediatyped": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-abstract-mediatyped/-/actor-abstract-mediatyped-2.10.0.tgz",
+      "integrity": "sha512-0o6WBujsMnIVcwvRJv6Nj+kKPLZzqBS3On48rm01Rh9T1/My0E/buJMXwgcARKCfMonc2mJ9zxpPCh5ilGEU2A==",
+      "dependencies": {
+        "@comunica/core": "^2.10.0",
+        "@comunica/types": "^2.10.0"
+      }
+    },
+    "node_modules/@comunica/actor-abstract-parse": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-abstract-parse/-/actor-abstract-parse-2.10.0.tgz",
+      "integrity": "sha512-0puCWF+y24EDOOAUUVVbC+tOf4UV+LzEbqi8T5v25jcVGCXyTqfra+bDywfrcv3adrVp18jLCJ46ycaH5xhy9Q==",
+      "dependencies": {
+        "@comunica/core": "^2.10.0",
+        "readable-stream": "^4.4.2"
+      }
+    },
+    "node_modules/@comunica/actor-abstract-path": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-abstract-path/-/actor-abstract-path-2.10.1.tgz",
+      "integrity": "sha512-+k1ltuUuIyn4iUm5oRMObyt2zhu68h7ymzxuKU4ezATlgwfwj6EM7/3W2n2/gxjg9tcFMr5GC6aNnFQmq3Iuig==",
+      "dependencies": {
+        "@comunica/bindings-factory": "^2.10.1",
+        "@comunica/bus-query-operation": "^2.10.1",
+        "@comunica/context-entries": "^2.10.0",
+        "@comunica/core": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.8.1",
+        "rdf-data-factory": "^1.1.1",
+        "rdf-string": "^1.6.1",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-context-preprocess-source-to-destination": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-context-preprocess-source-to-destination/-/actor-context-preprocess-source-to-destination-2.10.0.tgz",
+      "integrity": "sha512-sQc42Sd4cuVumZ9+PDnWBTBYneqCFShFliK8Et83GR3wBGzu9x0tS/M2o3e63sBbb6ZkWHyO5jl/O8AbrjhcTg==",
+      "dependencies": {
+        "@comunica/bus-context-preprocess": "^2.10.0",
+        "@comunica/context-entries": "^2.10.0",
+        "@comunica/core": "^2.10.0",
+        "@comunica/types": "^2.10.0"
+      }
+    },
+    "node_modules/@comunica/actor-dereference-fallback": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-dereference-fallback/-/actor-dereference-fallback-2.10.0.tgz",
+      "integrity": "sha512-RSc/ScPdC7l13aZjz/6r4niWA8WDETbzuESQKKSWXi/HAlFOyOxdrDADdayVY2oyeZHIQibeNRtSi2ItzU7OPQ==",
+      "dependencies": {
+        "@comunica/bus-dereference": "^2.10.0",
+        "@comunica/core": "^2.10.0"
+      }
+    },
+    "node_modules/@comunica/actor-dereference-file": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-dereference-file/-/actor-dereference-file-2.10.0.tgz",
+      "integrity": "sha512-WXfAyHm0M3+YbYEtLtasT6YHsrzTAevmH27ex8r51qKNj2LK74llpw4mSeea3xyjQR30jVnKBIJSxuSbN64Now==",
+      "dependencies": {
+        "@comunica/bus-dereference": "^2.10.0",
+        "@comunica/core": "^2.10.0"
+      }
+    },
+    "node_modules/@comunica/actor-dereference-http": {
+      "version": "2.10.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-dereference-http/-/actor-dereference-http-2.10.2.tgz",
+      "integrity": "sha512-gdDo83W1TAgD2jx0kVbzZKzzt++L4Y4fbyTOH3duy6vx1EMGGZlNCp6I1uguepKEjNX4N0zhAcZzdJcv8A3XMA==",
+      "dependencies": {
+        "@comunica/bus-dereference": "^2.10.0",
+        "@comunica/bus-http": "^2.10.2",
+        "@comunica/core": "^2.10.0",
+        "cross-fetch": "^4.0.0",
+        "relative-to-absolute-iri": "^1.0.7",
+        "stream-to-string": "^1.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-dereference-rdf-parse": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-dereference-rdf-parse/-/actor-dereference-rdf-parse-2.10.0.tgz",
+      "integrity": "sha512-ANWL6Bv+2WHUjVRS7hfkOfVBNJs8xYZ9KHlgBOQ94CKtQZB9uSMjdb1hLp/cQjiDmFIWLn0+GM5Xi0KFwBkVAw==",
+      "dependencies": {
+        "@comunica/bus-dereference": "^2.10.0",
+        "@comunica/bus-dereference-rdf": "^2.10.0",
+        "@comunica/bus-rdf-parse": "^2.10.0"
+      }
+    },
+    "node_modules/@comunica/actor-hash-bindings-sha1": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-hash-bindings-sha1/-/actor-hash-bindings-sha1-2.10.0.tgz",
+      "integrity": "sha512-f981PcCiDWbdZfM1ct1v1q/VII14y18lo1enEdHB25SF0hCkzIDwh9IrfDfJDju5I6luSWNE/MYMMeAAmF9e3g==",
+      "dependencies": {
+        "@comunica/bus-hash-bindings": "^2.10.0",
+        "@comunica/core": "^2.10.0",
+        "canonicalize": "^2.0.0",
+        "hash.js": "^1.1.7",
+        "rdf-string": "^1.6.1"
+      }
+    },
+    "node_modules/@comunica/actor-http-fetch": {
+      "version": "2.10.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-http-fetch/-/actor-http-fetch-2.10.2.tgz",
+      "integrity": "sha512-siHGx0TMVNb2gXvOroq0B3JE6uuS+4s+MsDkntqdBNVigwVYqLpNSKEaL5is8pputFfohJfDQY06lAHbfDNEcw==",
+      "dependencies": {
+        "@comunica/bus-http": "^2.10.2",
+        "@comunica/context-entries": "^2.10.0",
+        "@comunica/mediatortype-time": "^2.10.0",
+        "abort-controller": "^3.0.0",
+        "cross-fetch": "^4.0.0"
+      }
+    },
+    "node_modules/@comunica/actor-http-proxy": {
+      "version": "2.10.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-http-proxy/-/actor-http-proxy-2.10.2.tgz",
+      "integrity": "sha512-3yUF8BCh4nwq8J6NRILEsyNrQNStkE9ggJ7hYwRfA1XcMgz1pANNaWJ2P2TEKH1jNinr23bL3JeuUZCm9Kz9dA==",
+      "dependencies": {
+        "@comunica/bus-http": "^2.10.2",
+        "@comunica/context-entries": "^2.10.0",
+        "@comunica/mediatortype-time": "^2.10.0",
+        "@comunica/types": "^2.10.0"
+      }
+    },
+    "node_modules/@comunica/actor-http-wayback": {
+      "version": "2.10.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-http-wayback/-/actor-http-wayback-2.10.2.tgz",
+      "integrity": "sha512-wjYNXRrJvMqt9paO3HawyM+O5/14ofSHFuMAwGr/UyZQ5pCSFkY0YPd+qp9y8C4xvypPgsvT3PtiRyKgjD4FWw==",
+      "dependencies": {
+        "@comunica/bus-http": "^2.10.2",
+        "@comunica/context-entries": "^2.10.0",
+        "@comunica/core": "^2.10.0",
+        "cross-fetch": "^4.0.0",
+        "stream-to-string": "^1.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-init-query": {
+      "version": "2.10.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-init-query/-/actor-init-query-2.10.2.tgz",
+      "integrity": "sha512-7A4bXdKCjXRdUThvMOOyg+U17DPeBAsyDYz1SA8F4lPUR06NapcG5TmZF+YWUTN/2EG5fZPUnD3etKuPXreGUw==",
+      "dependencies": {
+        "@comunica/actor-http-proxy": "^2.10.2",
+        "@comunica/bus-context-preprocess": "^2.10.0",
+        "@comunica/bus-http-invalidate": "^2.10.0",
+        "@comunica/bus-init": "^2.10.0",
+        "@comunica/bus-optimize-query-operation": "^2.10.0",
+        "@comunica/bus-query-operation": "^2.10.1",
+        "@comunica/bus-query-parse": "^2.10.0",
+        "@comunica/bus-query-result-serialize": "^2.10.0",
+        "@comunica/context-entries": "^2.10.0",
+        "@comunica/core": "^2.10.0",
+        "@comunica/logger-pretty": "^2.10.0",
+        "@comunica/runner": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "@rdfjs/types": "*",
+        "@types/yargs": "^17.0.24",
+        "asynciterator": "^3.8.1",
+        "negotiate": "^1.0.1",
+        "rdf-quad": "^1.5.0",
+        "rdf-string": "^1.6.1",
+        "sparqlalgebrajs": "^4.2.0",
+        "streamify-string": "^1.0.1",
+        "yargs": "^17.7.2"
+      },
+      "optionalDependencies": {
+        "process": "^0.11.10"
+      }
+    },
+    "node_modules/@comunica/actor-optimize-query-operation-bgp-to-join": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-bgp-to-join/-/actor-optimize-query-operation-bgp-to-join-2.10.0.tgz",
+      "integrity": "sha512-M9vwM4a3VQA/ir8Q7eGRNzzx52u6RJFIXBW8p+Zkn+zv+4fsket3zLYJGhJU7dcvaSXcOi68rDP/r8KfgNXr4Q==",
+      "dependencies": {
+        "@comunica/bus-optimize-query-operation": "^2.10.0",
+        "@comunica/core": "^2.10.0",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-optimize-query-operation-join-bgp": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-join-bgp/-/actor-optimize-query-operation-join-bgp-2.10.0.tgz",
+      "integrity": "sha512-tzZojWPbWn/S0DZGjGfV90ZRJVWT/yX3DKGgZ1ur33U5TW8n/fBQxHNMPCLu0GkMQ1dyx6bU+ekILTqm+21Jyw==",
+      "dependencies": {
+        "@comunica/bus-optimize-query-operation": "^2.10.0",
+        "@comunica/core": "^2.10.0",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-optimize-query-operation-join-connected": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-join-connected/-/actor-optimize-query-operation-join-connected-2.10.0.tgz",
+      "integrity": "sha512-RsbKIAxX1HyoR/AUzqIV++dTcLiEElRIVDHYTaXVVvGgHECYdh9s+oc8cvv/lDbLVpfnc6P9C9BTAfrqOjKkhA==",
+      "dependencies": {
+        "@comunica/bus-optimize-query-operation": "^2.10.0",
+        "@comunica/core": "^2.10.0",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-ask": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-ask/-/actor-query-operation-ask-2.10.1.tgz",
+      "integrity": "sha512-7oktqE4fkMhi6Hs9XCcwwoZRsEismVqJZ5wp9lXXOPaxnHEiFyj5gb/B6baCstoCvCt6LcU8fVvfHSitbFCpeQ==",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^2.10.1",
+        "@comunica/core": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-bgp-join": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-bgp-join/-/actor-query-operation-bgp-join-2.10.1.tgz",
+      "integrity": "sha512-eNpnvgFyKlZEHkMzubYL8ndADSsAQH4rwXvh22CGnf0FwyndHr6TEpmE6j77m9vXiSJ/lda0U3Zv4vIXvtREOw==",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^2.10.1",
+        "@comunica/core": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-construct": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-construct/-/actor-query-operation-construct-2.10.1.tgz",
+      "integrity": "sha512-S+Nt1+1psv01QRnfytZjiog2NBNHIbjr7XIv+MO3p6aVmLCoZ6lmjxSGNdbX+EmcGr7tbbafXK5z3zRM+ke8Mw==",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^2.10.1",
+        "@comunica/core": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.8.1",
+        "rdf-data-factory": "^1.1.1",
+        "rdf-terms": "^1.11.0",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-describe-subject": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-describe-subject/-/actor-query-operation-describe-subject-2.10.1.tgz",
+      "integrity": "sha512-E8i0M6haJ5iZVeHMn5PbvA4G+l87mcZKqIxVpYAnJVpD667F74Dkx3IMbk+ohRmyRmnkOEmztUrjeyixHHzUEQ==",
+      "dependencies": {
+        "@comunica/actor-query-operation-union": "^2.10.1",
+        "@comunica/bus-query-operation": "^2.10.1",
+        "@comunica/core": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "asynciterator": "^3.8.1",
+        "rdf-data-factory": "^1.1.1",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-distinct-hash": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-distinct-hash/-/actor-query-operation-distinct-hash-2.10.1.tgz",
+      "integrity": "sha512-exvJbgcJ0Pe4EGbLJD5LuGpvaGcFeckCxwB5pyd9OewNke+tLLP7nbEjB8KFEPpCO9LE7zt4faB1HvpJdEHQKQ==",
+      "dependencies": {
+        "@comunica/bus-hash-bindings": "^2.10.0",
+        "@comunica/bus-query-operation": "^2.10.1",
+        "@comunica/core": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-extend": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-extend/-/actor-query-operation-extend-2.10.1.tgz",
+      "integrity": "sha512-wkZxUfDu8T5lXD+OFLItmjjbnEBqtv0z8pxVKgI/gX8mOeu5KcPWLH0dJODTWoIzIYrJhV25FmCgBks1rt6K8w==",
+      "dependencies": {
+        "@comunica/bindings-factory": "^2.10.1",
+        "@comunica/bus-query-operation": "^2.10.1",
+        "@comunica/core": "^2.10.0",
+        "@comunica/expression-evaluator": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-filter-sparqlee": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-filter-sparqlee/-/actor-query-operation-filter-sparqlee-2.10.1.tgz",
+      "integrity": "sha512-w2PnDNnlf+9B947ZdeSs7NpW9qGJjRiuODZYwhh0e6cx89GPDhEDVuJwawF6VP3m/oLcgXOAdif0Wwo3d8KNAA==",
+      "dependencies": {
+        "@comunica/bindings-factory": "^2.10.1",
+        "@comunica/bus-query-operation": "^2.10.1",
+        "@comunica/core": "^2.10.0",
+        "@comunica/expression-evaluator": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-from-quad": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-from-quad/-/actor-query-operation-from-quad-2.10.1.tgz",
+      "integrity": "sha512-7D4R8ONNJJPzoRu96dwIToOEk6/3O/T26FRzCqQKrbjFHNkX2v92KA/SiDzNz59VmDNWjYF1rsV31Ade6J89MA==",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^2.10.1",
+        "@comunica/core": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "@rdfjs/types": "*",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-group": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-group/-/actor-query-operation-group-2.10.1.tgz",
+      "integrity": "sha512-Od5s9Vb6uDPzXa6OAUC1WSMF96spNPJI2Zqf0Ixejw4zCNevOK/VwHivYfF0vHIUZxjRrOl3Al1ZU9L8n5Wxlw==",
+      "dependencies": {
+        "@comunica/bindings-factory": "^2.10.1",
+        "@comunica/bus-hash-bindings": "^2.10.0",
+        "@comunica/bus-query-operation": "^2.10.1",
+        "@comunica/core": "^2.10.0",
+        "@comunica/expression-evaluator": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.8.1",
+        "rdf-data-factory": "^1.1.1",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-join": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-join/-/actor-query-operation-join-2.10.1.tgz",
+      "integrity": "sha512-CGed1nSPvKsM8rvj/4KFME0lLnzlDMMEU+xGczu+BZW4FK+Z6RyBtHIUmy8SgFvNP1GXz83q8KnoecF5z8IpjA==",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^2.10.1",
+        "@comunica/bus-rdf-join": "^2.10.1",
+        "@comunica/core": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-leftjoin": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-leftjoin/-/actor-query-operation-leftjoin-2.10.1.tgz",
+      "integrity": "sha512-j0RwdoiV2WsCQnxcSa//m5FZ+ZHDRBm6ObsgpqS44WxzpV8rIB6Dq/3UxGgE7D2vK400JaiiHa3dFiHTwDF18w==",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^2.10.1",
+        "@comunica/bus-rdf-join": "^2.10.1",
+        "@comunica/core": "^2.10.0",
+        "@comunica/expression-evaluator": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-minus": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-minus/-/actor-query-operation-minus-2.10.1.tgz",
+      "integrity": "sha512-rUvHbc5/EUWMSJUgOEtxabCJ9IT9YThuG0FhcQk+BGRPGmsv2oz8uri5urKgCjfVXMH/09hRZksiDMqrmkQmZw==",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^2.10.1",
+        "@comunica/bus-rdf-join": "^2.10.1",
+        "@comunica/core": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-nop": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-nop/-/actor-query-operation-nop-2.10.1.tgz",
+      "integrity": "sha512-l/Z8Uuoq3AlSoxkgYjrP7O7Xc9h8Y3ZOh0f7UKCuAST3U5vPQ3k1YJckrRtdli8s0NHptN9TfZjwviEHuYbDFQ==",
+      "dependencies": {
+        "@comunica/bindings-factory": "^2.10.1",
+        "@comunica/bus-query-operation": "^2.10.1",
+        "@comunica/core": "^2.10.0",
+        "@comunica/metadata": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "asynciterator": "^3.8.1",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-orderby-sparqlee": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-orderby-sparqlee/-/actor-query-operation-orderby-sparqlee-2.10.1.tgz",
+      "integrity": "sha512-8D2JmCsBtqJC29zfiaAXNzZdsKybhDFo2F8iTHul3nQHxBC2CeKDrBnY70B/HpbWxkDE+pwMfSTEFc/CvNZN6A==",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^2.10.1",
+        "@comunica/core": "^2.10.0",
+        "@comunica/expression-evaluator": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "asynciterator": "^3.8.1",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-path-alt": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-alt/-/actor-query-operation-path-alt-2.10.1.tgz",
+      "integrity": "sha512-y1AHtkibThqHve79wAriXqrZ6hdLBhcdwyOpVqqEhY19a32P97Xv58bOwOkNeLguYdn/5CFlCTHz6dnzxUIoXg==",
+      "dependencies": {
+        "@comunica/actor-abstract-path": "^2.10.1",
+        "@comunica/actor-query-operation-union": "^2.10.1",
+        "@comunica/bus-query-operation": "^2.10.1",
+        "@comunica/types": "^2.10.0",
+        "asynciterator": "^3.8.1",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-path-inv": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-inv/-/actor-query-operation-path-inv-2.10.1.tgz",
+      "integrity": "sha512-pd30Ug7bOAZ5amfA3I6v+cpitlDn2i5fE1BA006LYJISCAHSfKEgLmU2Q4ZPbwi4s1A8WKKLV7Q389Ru3Xtziw==",
+      "dependencies": {
+        "@comunica/actor-abstract-path": "^2.10.1",
+        "@comunica/bus-query-operation": "^2.10.1",
+        "@comunica/types": "^2.10.0",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-path-link": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-link/-/actor-query-operation-path-link-2.10.1.tgz",
+      "integrity": "sha512-akujCHvCLmxaZ3gw9b1odDcqqAQnbbr9E8dTWLZyMJ4Mei8q/FmfWTF5MjGuQOas4UmQ3mm6gcqAKRZnJqlXNg==",
+      "dependencies": {
+        "@comunica/actor-abstract-path": "^2.10.1",
+        "@comunica/bus-query-operation": "^2.10.1",
+        "@comunica/types": "^2.10.0",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-path-nps": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-nps/-/actor-query-operation-path-nps-2.10.1.tgz",
+      "integrity": "sha512-5X3EUzn6Cygz94gNn1XWQQUZVp+de59sw8/rxPQqgwzdi1Y1O9zrLv+/7GqMJoLz6MHmDSgsceTIY4eC1qmmOQ==",
+      "dependencies": {
+        "@comunica/actor-abstract-path": "^2.10.1",
+        "@comunica/bus-query-operation": "^2.10.1",
+        "@comunica/types": "^2.10.0",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-path-one-or-more": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-one-or-more/-/actor-query-operation-path-one-or-more-2.10.1.tgz",
+      "integrity": "sha512-SkQeKESQqZOlzuMIsipcZ3ni7YfeyYMZCOtxC01HFbeyq+SDVbyfYUZ4Dd9uAi/g3InyzJRfou4csxHS8g7sHw==",
+      "dependencies": {
+        "@comunica/actor-abstract-path": "^2.10.1",
+        "@comunica/bindings-factory": "^2.10.1",
+        "@comunica/bus-query-operation": "^2.10.1",
+        "@comunica/types": "^2.10.0",
+        "asynciterator": "^3.8.1",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-path-seq": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-seq/-/actor-query-operation-path-seq-2.10.1.tgz",
+      "integrity": "sha512-8TYLdVYaq9oMd9cuLFay78103bOfvygQU/C8NtPdLI9kkRWFsBatvaKmykHOHQAvaLgNhniOlrIJNEpepZGnAQ==",
+      "dependencies": {
+        "@comunica/actor-abstract-path": "^2.10.1",
+        "@comunica/bus-query-operation": "^2.10.1",
+        "@comunica/bus-rdf-join": "^2.10.1",
+        "@comunica/types": "^2.10.0",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-path-zero-or-more": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-zero-or-more/-/actor-query-operation-path-zero-or-more-2.10.1.tgz",
+      "integrity": "sha512-DtqBSw4LV1KI3q1YYAwgXlWrz1PO4EUpe/bVri0UB3JSQnxjBMHuJlHn2crC9Z93tmizneXxfvtWlLSXRrehsw==",
+      "dependencies": {
+        "@comunica/actor-abstract-path": "^2.10.1",
+        "@comunica/bindings-factory": "^2.10.1",
+        "@comunica/bus-query-operation": "^2.10.1",
+        "@comunica/types": "^2.10.0",
+        "asynciterator": "^3.8.1",
+        "rdf-string": "^1.6.1",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-path-zero-or-one": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-zero-or-one/-/actor-query-operation-path-zero-or-one-2.10.1.tgz",
+      "integrity": "sha512-qePX+7iW5DXDwaYO210y7jhSU32Zk82S5UHuLLvd4q4HS1Z7j8e4KhukbeZKzQmOsO8S5JOHHM9vwvsOc3GPlw==",
+      "dependencies": {
+        "@comunica/actor-abstract-path": "^2.10.1",
+        "@comunica/bindings-factory": "^2.10.1",
+        "@comunica/bus-query-operation": "^2.10.1",
+        "@comunica/metadata": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "asynciterator": "^3.8.1",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-project": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-project/-/actor-query-operation-project-2.10.1.tgz",
+      "integrity": "sha512-KAaPl4GFIQMWR8I8OoJroktGssPKGbEEJHyGzTuYXrmJrcXgknOxf5IUSVJNpaFfS6dshT6nqW+ciT+wRzz0Tg==",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^2.10.1",
+        "@comunica/core": "^2.10.0",
+        "@comunica/data-factory": "^2.7.0",
+        "@comunica/types": "^2.10.0",
+        "@rdfjs/types": "*",
+        "rdf-data-factory": "^1.1.1",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-quadpattern": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-quadpattern/-/actor-query-operation-quadpattern-2.10.1.tgz",
+      "integrity": "sha512-RZj1TXW+VDU4aYJVnSzgs8q0340e+YUeGLtoY9sl0Xzc8YNaIus4nXRUz/KfOXDknxm1q+a4Bof4yHNgXtb1Hw==",
+      "dependencies": {
+        "@comunica/bindings-factory": "^2.10.1",
+        "@comunica/bus-query-operation": "^2.10.1",
+        "@comunica/bus-rdf-resolve-quad-pattern": "^2.10.0",
+        "@comunica/context-entries": "^2.10.0",
+        "@comunica/core": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.8.1",
+        "rdf-data-factory": "^1.1.1",
+        "rdf-string": "^1.6.3",
+        "rdf-terms": "^1.11.0",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-reduced-hash": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-reduced-hash/-/actor-query-operation-reduced-hash-2.10.1.tgz",
+      "integrity": "sha512-9hX25ztkbNxnaUd7Gtilok+9WJkr/s3a3y4axLoYX4/nOogYN+nZRKChvNSn4qn/lWvpG5VWv4+q0en1fP+AGA==",
+      "dependencies": {
+        "@comunica/bus-hash-bindings": "^2.10.0",
+        "@comunica/bus-query-operation": "^2.10.1",
+        "@comunica/core": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "lru-cache": "^10.0.0",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-reduced-hash/node_modules/lru-cache": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.2.0.tgz",
+      "integrity": "sha512-2bIM8x+VAf6JT4bKAljS1qUWgMsqZRPGJS6FSahIMPVvctcNhyVp7AJu7quxOW9jwkryBReKZY5tY5JYv2n/7Q==",
+      "engines": {
+        "node": "14 || >=16.14"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-service": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-service/-/actor-query-operation-service-2.10.1.tgz",
+      "integrity": "sha512-GvpvhUmhkVFOCLrmcblgIPqi91XPRog5WkC9NFMRCToaSNAMQq82DX2dvwzn3IFItcmyZrmy+GYoaQ9miK2uVQ==",
+      "dependencies": {
+        "@comunica/bindings-factory": "^2.10.1",
+        "@comunica/bus-query-operation": "^2.10.1",
+        "@comunica/context-entries": "^2.10.0",
+        "@comunica/core": "^2.10.0",
+        "@comunica/metadata": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "asynciterator": "^3.8.1",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-slice": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-slice/-/actor-query-operation-slice-2.10.1.tgz",
+      "integrity": "sha512-KOBnTIUvwf28WB7oHevUC/xciEdH5gLg7MN8DvamkAkUiUjviEsRpkswUiD8lFe1dAs0ekA4pC0NoZ8BWp3uqA==",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^2.10.1",
+        "@comunica/context-entries": "^2.10.0",
+        "@comunica/core": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-sparql-endpoint": {
+      "version": "2.10.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-sparql-endpoint/-/actor-query-operation-sparql-endpoint-2.10.2.tgz",
+      "integrity": "sha512-nbBzVHhYHUu/9qg9ZzTw7rKvsRb3ViBvM+Fye0oMXojZUbyu2WI6eLFUc2Ze1/LYDNf/1KHNpkg6OdsiEi8HFQ==",
+      "dependencies": {
+        "@comunica/bindings-factory": "^2.10.1",
+        "@comunica/bus-http": "^2.10.2",
+        "@comunica/bus-query-operation": "^2.10.1",
+        "@comunica/bus-rdf-resolve-quad-pattern": "^2.10.0",
+        "@comunica/bus-rdf-update-quads": "^2.10.2",
+        "@comunica/context-entries": "^2.10.0",
+        "@comunica/core": "^2.10.0",
+        "@comunica/mediatortype-httprequests": "^2.10.0",
+        "@comunica/metadata": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.8.1",
+        "fetch-sparql-endpoint": "^4.1.0",
+        "rdf-data-factory": "^1.1.1",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-union": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-union/-/actor-query-operation-union-2.10.1.tgz",
+      "integrity": "sha512-Ezi2bAa9r6yyffXDDUPLlKoszsXnuhDUeQSQuU3c7JEAcwip3wC3zMNkavowwfRZ/1D5doitmUEdw2lAd+xloA==",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^2.10.1",
+        "@comunica/core": "^2.10.0",
+        "@comunica/metadata": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.8.1",
+        "rdf-terms": "^1.11.0",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-update-add-rewrite": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-add-rewrite/-/actor-query-operation-update-add-rewrite-2.10.1.tgz",
+      "integrity": "sha512-is3mrCPciExrlny5JbCvB011kUNYE9/fzQc/zmA3h24S5hHZbygA9mSS+dI85IwwqdKPYlrEqfn8c0kCVWMKyw==",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^2.10.1",
+        "@comunica/core": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "rdf-data-factory": "^1.1.1",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-update-clear": {
+      "version": "2.10.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-clear/-/actor-query-operation-update-clear-2.10.2.tgz",
+      "integrity": "sha512-+sf6+LvXdKBv2pCuBH/ad5QdpheZSPEvw19UoaPQRQyQVBzIskOtfs4rwJHSn/YmoqhbstKZszakad3oxWwTTg==",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^2.10.1",
+        "@comunica/bus-rdf-update-quads": "^2.10.2",
+        "@comunica/core": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "@rdfjs/types": "*",
+        "rdf-data-factory": "^1.1.1",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-update-compositeupdate": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-compositeupdate/-/actor-query-operation-update-compositeupdate-2.10.1.tgz",
+      "integrity": "sha512-IVNouBPFQLOczhW3qHyEoyxWrc7wnVT2vPwRHEaGlfnSiYAX42XSNLb9jR0XjB70wh3Civue4Ovs3upOXdrN3Q==",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^2.10.1",
+        "@comunica/core": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-update-copy-rewrite": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-copy-rewrite/-/actor-query-operation-update-copy-rewrite-2.10.1.tgz",
+      "integrity": "sha512-l/3AM35hjahyHmiLoB3FPm0Jlhdmd/vqgOGj7V3Ra+TfHo5h8XOB3uzG78Q06HQNw4iyONBZc5lLlYXkzRd5lg==",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^2.10.1",
+        "@comunica/core": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-update-create": {
+      "version": "2.10.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-create/-/actor-query-operation-update-create-2.10.2.tgz",
+      "integrity": "sha512-g3DwLkYFTU8uZoIOV7oNPWStBmqvnBBPvLngG19MQQezuVoh8w88efxhbN0B/khi5/v4qcLsr7C0ffAaPF8Fbg==",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^2.10.1",
+        "@comunica/bus-rdf-update-quads": "^2.10.2",
+        "@comunica/core": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-update-deleteinsert": {
+      "version": "2.10.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-deleteinsert/-/actor-query-operation-update-deleteinsert-2.10.2.tgz",
+      "integrity": "sha512-FiRCLUAxkDoFpOe9jKC5llI7njbFdb1N8McRvZjBazUS4XDutjTZEkcKLs6AcRyG3esfHt6gNm6PqCuZ+aP8TA==",
+      "dependencies": {
+        "@comunica/actor-query-operation-construct": "^2.10.1",
+        "@comunica/bindings-factory": "^2.10.1",
+        "@comunica/bus-query-operation": "^2.10.1",
+        "@comunica/bus-rdf-update-quads": "^2.10.2",
+        "@comunica/core": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.8.1",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-update-drop": {
+      "version": "2.10.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-drop/-/actor-query-operation-update-drop-2.10.2.tgz",
+      "integrity": "sha512-N/878InwoyQfysjCyo9r+H82eUlNeEGODJ95gCvzF/QGRc11N3dfcd3XijyHQ9OKAoQ9oR5gcS829LB3BDtKHg==",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^2.10.1",
+        "@comunica/bus-rdf-update-quads": "^2.10.2",
+        "@comunica/core": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "@rdfjs/types": "*",
+        "rdf-data-factory": "^1.1.1",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-update-load": {
+      "version": "2.10.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-load/-/actor-query-operation-update-load-2.10.2.tgz",
+      "integrity": "sha512-lQb5fxb1+ZFbQkylmepze+e+LtVmVNvAvFBvjxUSfCT62uIKKHMeh1So5kTrGD0Co4ABCs1h6o9WB+8yQzFtQw==",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^2.10.1",
+        "@comunica/bus-rdf-update-quads": "^2.10.2",
+        "@comunica/context-entries": "^2.10.0",
+        "@comunica/core": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "rdf-data-factory": "^1.1.1",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-update-move-rewrite": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-update-move-rewrite/-/actor-query-operation-update-move-rewrite-2.10.1.tgz",
+      "integrity": "sha512-GDLSHG2++EAAyUKhDu+mM6QfMTuzM8dS24HqeQL5Wzbkdc2KTmNKyJuhJw6SfXr6EiF/kxf1GPY6zwjcwACx/w==",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^2.10.1",
+        "@comunica/core": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-values": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-values/-/actor-query-operation-values-2.10.1.tgz",
+      "integrity": "sha512-++9IgCVCQPIF8fzZLmrVpxPj8eI9TvkLshHAugQQBnhSijrDMUudW9eoA+eFmCaD/Ru7YtlKe3OJzRGV8FCG+Q==",
+      "dependencies": {
+        "@comunica/bindings-factory": "^2.10.1",
+        "@comunica/bus-query-operation": "^2.10.1",
+        "@comunica/core": "^2.10.0",
+        "@comunica/metadata": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "asynciterator": "^3.8.1",
+        "rdf-data-factory": "^1.1.1",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-parse-graphql": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-parse-graphql/-/actor-query-parse-graphql-2.10.0.tgz",
+      "integrity": "sha512-l3RrkxElDYV4weXt3vpC0Q0She4AhbvPbPDronQulgN9nFAZhz4z9k8800T5uWMsL98wHNNXDFlnFk5S38lsow==",
+      "dependencies": {
+        "@comunica/bus-query-parse": "^2.10.0",
+        "@comunica/context-entries": "^2.10.0",
+        "@comunica/core": "^2.10.0",
+        "graphql-to-sparql": "^3.0.1"
+      }
+    },
+    "node_modules/@comunica/actor-query-parse-sparql": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-parse-sparql/-/actor-query-parse-sparql-2.10.0.tgz",
+      "integrity": "sha512-DUVAuSSNn0AyvLruOpRpLZBsr96Q4LuV1gcO+alKZALtfOZikRKY/3sXz1NUkaRQc7qDH9xFFTFrfJd0jLvlDA==",
+      "dependencies": {
+        "@comunica/bus-query-parse": "^2.10.0",
+        "@comunica/core": "^2.10.0",
+        "@types/sparqljs": "^3.1.3",
+        "sparqlalgebrajs": "^4.2.0",
+        "sparqljs": "^3.7.1"
+      }
+    },
+    "node_modules/@comunica/actor-query-result-serialize-json": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-result-serialize-json/-/actor-query-result-serialize-json-2.10.0.tgz",
+      "integrity": "sha512-GuVcsOEhKgnVPT0AaCn8sJl/Uj5UUjUktEJpuMx1UAYt0//jcQsezJslYWmJrfXE/WJYidynyDxm8z3+jwLF7A==",
+      "dependencies": {
+        "@comunica/bus-query-result-serialize": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "rdf-string": "^1.6.1",
+        "readable-stream": "^4.4.2"
+      }
+    },
+    "node_modules/@comunica/actor-query-result-serialize-rdf": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-result-serialize-rdf/-/actor-query-result-serialize-rdf-2.10.0.tgz",
+      "integrity": "sha512-TBXJrDs5brRMFg8UisXS/F1vJw8nUtLhjugNZcd4ST8J965Ho1aNopydp4PMmwINMRxHhHtWJGwIB2Z5xD2lDw==",
+      "dependencies": {
+        "@comunica/bus-query-result-serialize": "^2.10.0",
+        "@comunica/bus-rdf-serialize": "^2.10.0",
+        "@comunica/core": "^2.10.0",
+        "@comunica/types": "^2.10.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-result-serialize-simple": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-result-serialize-simple/-/actor-query-result-serialize-simple-2.10.0.tgz",
+      "integrity": "sha512-pS7+aB9Rym1B5oi+O68NFjEq+EwpCRYtTIxGBp39CTQ0F7m4edt9QwqmARqveJPryK5X66ACvjxvutEaTgWI8w==",
+      "dependencies": {
+        "@comunica/bus-query-result-serialize": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "@rdfjs/types": "*",
+        "rdf-string": "^1.6.3",
+        "readable-stream": "^4.4.2"
+      }
+    },
+    "node_modules/@comunica/actor-query-result-serialize-sparql-csv": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-result-serialize-sparql-csv/-/actor-query-result-serialize-sparql-csv-2.10.0.tgz",
+      "integrity": "sha512-Vk+7oTIPigDENK3CnV56vLfvMZVjHc3p2F4a49WDHfMgRrfQKJSQkx603vjW35n3tmUB8JSgRXr/+v7LK83KYQ==",
+      "dependencies": {
+        "@comunica/bus-query-result-serialize": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "@rdfjs/types": "*",
+        "readable-stream": "^4.4.2"
+      }
+    },
+    "node_modules/@comunica/actor-query-result-serialize-sparql-json": {
+      "version": "2.10.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-result-serialize-sparql-json/-/actor-query-result-serialize-sparql-json-2.10.2.tgz",
+      "integrity": "sha512-+J7SWXc4nXHzmQMk6q8MScrLNKdqX+/xQe6XCk0zDbDAt3/8EJh/2ROYFp4fEQyPDFWOwN4xpALgHRIh8PQRAQ==",
+      "dependencies": {
+        "@comunica/bus-http": "^2.10.2",
+        "@comunica/bus-http-invalidate": "^2.10.0",
+        "@comunica/bus-query-result-serialize": "^2.10.0",
+        "@comunica/core": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "@rdfjs/types": "*",
+        "readable-stream": "^4.4.2"
+      }
+    },
+    "node_modules/@comunica/actor-query-result-serialize-sparql-tsv": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-result-serialize-sparql-tsv/-/actor-query-result-serialize-sparql-tsv-2.10.0.tgz",
+      "integrity": "sha512-TgA2WIXKdu/SrbHEP8HvGoLjhDOZnBoHsGsLFSHpxY/Uwk21rZqJLBEkhuhkUtGYzQPJ1n6Wmpjz9lBrUHGJPw==",
+      "dependencies": {
+        "@comunica/bus-query-result-serialize": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "@rdfjs/types": "*",
+        "rdf-string-ttl": "^1.3.2",
+        "readable-stream": "^4.4.2"
+      }
+    },
+    "node_modules/@comunica/actor-query-result-serialize-sparql-xml": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-result-serialize-sparql-xml/-/actor-query-result-serialize-sparql-xml-2.10.0.tgz",
+      "integrity": "sha512-8RDj5ZN23HnIc6zI5pD5XKi2pyg2cx6DhI7VDRcboi7v0DxfROuQqSEtbQ8m/W6Pngdz01ySogRcIVJCzRzBLQ==",
+      "dependencies": {
+        "@comunica/bus-query-result-serialize": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "@rdfjs/types": "*",
+        "readable-stream": "^4.4.2"
+      }
+    },
+    "node_modules/@comunica/actor-query-result-serialize-stats": {
+      "version": "2.10.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-result-serialize-stats/-/actor-query-result-serialize-stats-2.10.2.tgz",
+      "integrity": "sha512-jhj/vLDRxLuRMonBaqICt4saM9/UO9wJBT3Jxk7Rp73aQWLo+lILXKzcWpuxkh/EFx8raLUBmbjWCduamU1DzQ==",
+      "dependencies": {
+        "@comunica/bus-http": "^2.10.2",
+        "@comunica/bus-http-invalidate": "^2.10.0",
+        "@comunica/bus-query-result-serialize": "^2.10.0",
+        "@comunica/core": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "process": "^0.11.10",
+        "readable-stream": "^4.4.2"
+      }
+    },
+    "node_modules/@comunica/actor-query-result-serialize-table": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-result-serialize-table/-/actor-query-result-serialize-table-2.10.0.tgz",
+      "integrity": "sha512-AAPrgM/rbsSThRu9jkfJhBUeTUwQTLHNVbIn8El+Akvz+Fueoi6oSi3SslpPMHOvIUiOAgCZ05f2RbBLlhP03g==",
+      "dependencies": {
+        "@comunica/bus-query-result-serialize": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "@rdfjs/types": "*",
+        "rdf-data-factory": "^1.1.1",
+        "rdf-string": "^1.6.3",
+        "rdf-terms": "^1.11.0",
+        "readable-stream": "^4.4.2"
+      }
+    },
+    "node_modules/@comunica/actor-query-result-serialize-tree": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-result-serialize-tree/-/actor-query-result-serialize-tree-2.10.0.tgz",
+      "integrity": "sha512-sEyIzoSTV11YPY6r4fn6fwrf3WjLD6GrwXMTuevsDAKDYaMYxyriH3T/LMLLBEURy8SLD1I1Fpw/qaZisRmLTg==",
+      "dependencies": {
+        "@comunica/bus-query-result-serialize": "^2.10.0",
+        "@comunica/context-entries": "^2.10.0",
+        "@comunica/core": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "readable-stream": "^4.4.2",
+        "sparqljson-to-tree": "^3.0.1"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-join-entries-sort-cardinality": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-entries-sort-cardinality/-/actor-rdf-join-entries-sort-cardinality-2.10.0.tgz",
+      "integrity": "sha512-6dd/29q6QuQN2Ap090VA0KUFmmnHalPxFJb4MGh5nIbWZH0F/EvI+uK5vPx29cttr1yXL5u+MbJWaLb3IxwILg==",
+      "dependencies": {
+        "@comunica/bus-rdf-join-entries-sort": "^2.10.0",
+        "@comunica/core": "^2.10.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-join-inner-hash": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-hash/-/actor-rdf-join-inner-hash-2.10.1.tgz",
+      "integrity": "sha512-nUtdS3NJGKSJQC8KjDVz4TEDmkXHBYQi0/bwnAXCDl1phhq8lgv+YEmRDNe/kuCze7HyqEt98rlSJ+ZhvcHXVQ==",
+      "dependencies": {
+        "@comunica/bus-rdf-join": "^2.10.1",
+        "@comunica/mediatortype-join-coefficients": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "asyncjoin": "^1.1.1"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-join-inner-multi-bind": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-multi-bind/-/actor-rdf-join-inner-multi-bind-2.10.1.tgz",
+      "integrity": "sha512-tNZ2Q7z44Yr0iIFkvtTVAsts4v0IoC4b0FYaIUeYav4y5JOlR74hWWijTAzVfb31dTMsAp3r+y0xGIdd75LRHQ==",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^2.10.1",
+        "@comunica/bus-rdf-join": "^2.10.1",
+        "@comunica/bus-rdf-join-entries-sort": "^2.10.0",
+        "@comunica/context-entries": "^2.10.0",
+        "@comunica/mediatortype-join-coefficients": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "asynciterator": "^3.8.1",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-join-inner-multi-empty": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-multi-empty/-/actor-rdf-join-inner-multi-empty-2.10.1.tgz",
+      "integrity": "sha512-z6a3qENwuvSU0PvqOySrsHsWSUvzfWd1xIYwEvKuEIJ9vYPoefIUgggx08E95ZF/k+PxZ0vKEywFpBSUKUzGYA==",
+      "dependencies": {
+        "@comunica/bus-rdf-join": "^2.10.1",
+        "@comunica/mediatortype-join-coefficients": "^2.10.0",
+        "@comunica/metadata": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "asynciterator": "^3.8.1"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-join-inner-multi-smallest": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-multi-smallest/-/actor-rdf-join-inner-multi-smallest-2.10.1.tgz",
+      "integrity": "sha512-MXwIvq+viDCmsxJwD4+fwMhwZINWva3jtQ3j5ne6DXgZYUJUFOw3VujvCP4/cl075RuSxYlXgy6ETHLa1TNr7g==",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^2.10.1",
+        "@comunica/bus-rdf-join": "^2.10.1",
+        "@comunica/bus-rdf-join-entries-sort": "^2.10.0",
+        "@comunica/mediatortype-join-coefficients": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-join-inner-nestedloop": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-nestedloop/-/actor-rdf-join-inner-nestedloop-2.10.1.tgz",
+      "integrity": "sha512-nFjGMrAIrRjRcsaU8UQXLbsDODVdf4LDpVNVQIrjfoWzhOIy13ApDQrqtuObaGVfryiFgt34zVEOwMWezWzl0A==",
+      "dependencies": {
+        "@comunica/bus-rdf-join": "^2.10.1",
+        "@comunica/mediatortype-join-coefficients": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "asyncjoin": "^1.1.1"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-join-inner-none": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-none/-/actor-rdf-join-inner-none-2.10.1.tgz",
+      "integrity": "sha512-4mqsuqvLSuXMbgY0PghqK5hmBGH5YkRTwUOpGpBE0EVQaiAoQOME0uVslkt2TBzUx5IQJC+trr/80sbA9mAhMw==",
+      "dependencies": {
+        "@comunica/bindings-factory": "^2.10.1",
+        "@comunica/bus-rdf-join": "^2.10.1",
+        "@comunica/mediatortype-join-coefficients": "^2.10.0",
+        "@comunica/metadata": "^2.10.0",
+        "asynciterator": "^3.8.1"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-join-inner-single": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-single/-/actor-rdf-join-inner-single-2.10.1.tgz",
+      "integrity": "sha512-RfnwTEsuXNdR0cNRWaCvNPlfD5KyuScsc/55j/9mr8yqGUTE9h9Om1Is5u7xnpRMxGOEqwVP6apK3ZxsZqlL/w==",
+      "dependencies": {
+        "@comunica/bus-rdf-join": "^2.10.1",
+        "@comunica/mediatortype-join-coefficients": "^2.10.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-join-inner-symmetrichash": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-symmetrichash/-/actor-rdf-join-inner-symmetrichash-2.10.1.tgz",
+      "integrity": "sha512-beFGkMUe3pTADtMXXPU8ab/IMULj+Hkg3Iah0zgrVZgwWH1Kgfkj/2qp32Ll5y9qcRbio4ruruKlHNXJJUU46Q==",
+      "dependencies": {
+        "@comunica/bus-rdf-join": "^2.10.1",
+        "@comunica/mediatortype-join-coefficients": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "asyncjoin": "^1.1.1"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-join-minus-hash": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-minus-hash/-/actor-rdf-join-minus-hash-2.10.1.tgz",
+      "integrity": "sha512-wIaB/EpuySaARhimoLzrE0cTH0TgVkL43IAtYX7ECwH9Qcv8blO4zbL4q2KUkY7OKZRM892aqMfo3kO1vMIK7w==",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^2.10.1",
+        "@comunica/bus-rdf-join": "^2.10.1",
+        "@comunica/mediatortype-join-coefficients": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "@rdfjs/types": "*"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-join-minus-hash-undef": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-minus-hash-undef/-/actor-rdf-join-minus-hash-undef-2.10.1.tgz",
+      "integrity": "sha512-tz5LdeAHnylEQIq4bRfFqaH89WZXkkdFxEshqxWijFBp5wprUYiotMDrBo9zDFaPquhs42fILtTzLY9yaalc9w==",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^2.10.1",
+        "@comunica/bus-rdf-join": "^2.10.1",
+        "@comunica/mediatortype-join-coefficients": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "@rdfjs/types": "*",
+        "rdf-string": "^1.6.1"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-join-optional-bind": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-optional-bind/-/actor-rdf-join-optional-bind-2.10.1.tgz",
+      "integrity": "sha512-6dOoI/rzRZ0RUyv2WlToClE42Z2YJE5xcSrot7haT2eMdxbzr1KjyasHBcIIkSK+WViDO006lXZ1Hi4tJm9uuA==",
+      "dependencies": {
+        "@comunica/actor-rdf-join-inner-multi-bind": "^2.10.1",
+        "@comunica/bus-query-operation": "^2.10.1",
+        "@comunica/bus-rdf-join": "^2.10.1",
+        "@comunica/context-entries": "^2.10.0",
+        "@comunica/mediatortype-join-coefficients": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-join-optional-nestedloop": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-optional-nestedloop/-/actor-rdf-join-optional-nestedloop-2.10.1.tgz",
+      "integrity": "sha512-d7KUDjEKZszizd4SBvYkK2A6lScrq9ciEgzdrrp6IYZhIGAhJLTgPNg3Js3NEjpE7oj4KWl2WwKJe2sWcJbKJg==",
+      "dependencies": {
+        "@comunica/bus-rdf-join": "^2.10.1",
+        "@comunica/mediatortype-join-coefficients": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "asyncjoin": "^1.1.1"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-join-selectivity-variable-counting": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-selectivity-variable-counting/-/actor-rdf-join-selectivity-variable-counting-2.10.0.tgz",
+      "integrity": "sha512-D7tdzxA93bpZGXI5emJyvzk6LabeAnzcQMU/V5x2QwJxyoNr+LFbesBHDDP3/u4UJwmeP0a+dU0e5mbpJujSXw==",
+      "dependencies": {
+        "@comunica/bus-rdf-join-selectivity": "^2.10.0",
+        "@comunica/core": "^2.10.0",
+        "@comunica/mediatortype-accuracy": "^2.10.0",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-metadata-accumulate-cancontainundefs": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-accumulate-cancontainundefs/-/actor-rdf-metadata-accumulate-cancontainundefs-2.10.0.tgz",
+      "integrity": "sha512-N3rwX4kT9rkW+89q4xCjO3KKG0DbeNIyeMWDzeh2vTw8nAXYyTiPjHYvx/6VUMzhFUWF+50VtVv8ZJPO6nEapw==",
+      "dependencies": {
+        "@comunica/bus-rdf-metadata-accumulate": "^2.10.0",
+        "@comunica/core": "^2.10.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-metadata-accumulate-cardinality": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-accumulate-cardinality/-/actor-rdf-metadata-accumulate-cardinality-2.10.0.tgz",
+      "integrity": "sha512-UpC5PbhzEDCAxTUqETH89uRaFRqmP6YuWt67OAPo5wocv2tQDs6/SdLwS695XnfeMJdfDHsXyoUzQg3r8dwydw==",
+      "dependencies": {
+        "@comunica/bus-rdf-metadata-accumulate": "^2.10.0",
+        "@comunica/core": "^2.10.0",
+        "@comunica/types": "^2.10.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-metadata-accumulate-pagesize": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-accumulate-pagesize/-/actor-rdf-metadata-accumulate-pagesize-2.10.0.tgz",
+      "integrity": "sha512-r364CWGr5rMpV2ec3TsD+9Yhvi1JUuRXLBQqtgzjAPbpWjfDSM1Q4h0P1z9h3D+sdUMEX/0iGAY3AH2FjJAxwA==",
+      "dependencies": {
+        "@comunica/bus-rdf-metadata-accumulate": "^2.10.0",
+        "@comunica/core": "^2.10.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-metadata-accumulate-requesttime": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-accumulate-requesttime/-/actor-rdf-metadata-accumulate-requesttime-2.10.0.tgz",
+      "integrity": "sha512-SpG7gxxAPoW2NbgyZ2UNpwluJ+IvCOYIRDTXmVTAK8bntav+/ZG30yfESFBjB3LmJEwAnktAsTgM6OhldohPKw==",
+      "dependencies": {
+        "@comunica/bus-rdf-metadata-accumulate": "^2.10.0",
+        "@comunica/core": "^2.10.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-metadata-all": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-all/-/actor-rdf-metadata-all-2.10.0.tgz",
+      "integrity": "sha512-dHaSxHTdneWVBMAF6WqZrGD+u4TPpHQaJ2WutK1NvQNPIiF0N7249aGTvXBIXZfsKYyQ73PUORDeLEOjX+tT7g==",
+      "dependencies": {
+        "@comunica/bus-rdf-metadata": "^2.10.0",
+        "@comunica/core": "^2.10.0",
+        "readable-stream": "^4.4.2"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-metadata-extract-allow-http-methods": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-allow-http-methods/-/actor-rdf-metadata-extract-allow-http-methods-2.10.0.tgz",
+      "integrity": "sha512-aCSX+lWcmz5Q/g34VJEblczqDS6N+gJ3AlcOcGuqhd6qHRU17dMeCIZCk8p6p+AhbJ30w4BTsrZRY2sF0MGCVA==",
+      "dependencies": {
+        "@comunica/bus-rdf-metadata-extract": "^2.10.0",
+        "@comunica/core": "^2.10.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-metadata-extract-hydra-controls": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-hydra-controls/-/actor-rdf-metadata-extract-hydra-controls-2.10.0.tgz",
+      "integrity": "sha512-T6F5OaQNqrHVIwSGNRX6YPDBoAOYBQj3NTPID7vQae7J80oEX+CLoTkeJJwfHpoUWx0ihs8J0UkABgK3AWeylA==",
+      "dependencies": {
+        "@comunica/bus-rdf-metadata-extract": "^2.10.0",
+        "@comunica/core": "^2.10.0",
+        "@rdfjs/types": "*",
+        "@types/uritemplate": "^0.3.4",
+        "uritemplate": "0.3.4"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-metadata-extract-hydra-count": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-hydra-count/-/actor-rdf-metadata-extract-hydra-count-2.10.0.tgz",
+      "integrity": "sha512-nOMLN+9OSLFOVz6jc9pcyDizhcBBVT2azn7StTMK5ukFCcPCENS4y6lYhC5cijKZY7vUa7U6VzhX2vvw20MKDA==",
+      "dependencies": {
+        "@comunica/bus-rdf-metadata-extract": "^2.10.0",
+        "@comunica/core": "^2.10.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-metadata-extract-hydra-pagesize": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-hydra-pagesize/-/actor-rdf-metadata-extract-hydra-pagesize-2.10.0.tgz",
+      "integrity": "sha512-mD8KS2ENr2rbfBWxtVpxkB/Y2LyyAnwQU5UYKkpet8ELhlostdGROzYCNIAgfOgirOAsLgVkbmrX0XBGouI7rA==",
+      "dependencies": {
+        "@comunica/bus-rdf-metadata-extract": "^2.10.0",
+        "@comunica/core": "^2.10.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-metadata-extract-patch-sparql-update": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-patch-sparql-update/-/actor-rdf-metadata-extract-patch-sparql-update-2.10.0.tgz",
+      "integrity": "sha512-U5ARpeWKShbbSfdtJeb6nyPcsdtMwEo2dp56T4aSTNSBKtAhQ78DjOxb23WIU/VR/qpw2yWcsbPnNJvSaLpRVQ==",
+      "dependencies": {
+        "@comunica/bus-rdf-metadata-extract": "^2.10.0",
+        "@comunica/core": "^2.10.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-metadata-extract-put-accepted": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-put-accepted/-/actor-rdf-metadata-extract-put-accepted-2.10.0.tgz",
+      "integrity": "sha512-cGJg6tMMCOSGcitkUBN7b9/Sg5zgwWQC52g+Zk22o4i+Zgt24WLjfXXbnGWGoV+h9YZo8pkg7v1cpE5GpapNCg==",
+      "dependencies": {
+        "@comunica/bus-rdf-metadata-extract": "^2.10.0",
+        "@comunica/core": "^2.10.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-metadata-extract-request-time": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-request-time/-/actor-rdf-metadata-extract-request-time-2.10.0.tgz",
+      "integrity": "sha512-zh3coTPZMbgF4mXKCO3bzn99INt9HFraKMZWc9s/kwBE6vhNZ5246Ql/6z1v7mccoIbanhI72gtjFTGGHru80Q==",
+      "dependencies": {
+        "@comunica/bus-rdf-metadata-extract": "^2.10.0",
+        "@comunica/core": "^2.10.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-metadata-extract-sparql-service": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-sparql-service/-/actor-rdf-metadata-extract-sparql-service-2.10.0.tgz",
+      "integrity": "sha512-Xc+id8FURTmY3ccb4hcVuAaOou5UqD+1YkTnGfMWQxVgMlFC1eeBvwWVzvedj0sHhnfbLgDwbCVYLCK1lNndSg==",
+      "dependencies": {
+        "@comunica/bus-rdf-metadata-extract": "^2.10.0",
+        "@comunica/core": "^2.10.0",
+        "relative-to-absolute-iri": "^1.0.7"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-metadata-primary-topic": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-primary-topic/-/actor-rdf-metadata-primary-topic-2.10.0.tgz",
+      "integrity": "sha512-nabxkiYSPGPRylhYjGxF0KiJ/K8QiG1N/am/t8eaqwyjn/fo2/tHl0yXUaLLx0E8fChfbBv10sVlmLhsLrg8DQ==",
+      "dependencies": {
+        "@comunica/bus-rdf-metadata": "^2.10.0",
+        "@comunica/core": "^2.10.0",
+        "@rdfjs/types": "*",
+        "readable-stream": "^4.4.2"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-parse-html": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html/-/actor-rdf-parse-html-2.10.0.tgz",
+      "integrity": "sha512-zgImXKpc+BN1i6lQiN1Qhlb1HbKdMIeJMOys6qbzRIijdK8GkGGChwhQp7Cso3lY1Nf4K7M3jPLZeQXeED2w7g==",
+      "dependencies": {
+        "@comunica/bus-rdf-parse": "^2.10.0",
+        "@comunica/bus-rdf-parse-html": "^2.10.0",
+        "@comunica/core": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "@rdfjs/types": "*",
+        "htmlparser2": "^9.0.0",
+        "readable-stream": "^4.4.2"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-parse-html-microdata": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html-microdata/-/actor-rdf-parse-html-microdata-2.10.0.tgz",
+      "integrity": "sha512-JLfiDauq4SmpI6TDS4HaHzI6iJe1j8lSk5FRRYK6YVEu8eO28jPmxQJiOiwbQiYqsjsV7kON/WIZSoUELoI4Ig==",
+      "dependencies": {
+        "@comunica/bus-rdf-parse-html": "^2.10.0",
+        "@comunica/core": "^2.10.0",
+        "microdata-rdf-streaming-parser": "^2.0.1"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-parse-html-rdfa": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html-rdfa/-/actor-rdf-parse-html-rdfa-2.10.0.tgz",
+      "integrity": "sha512-9K3iaws9+FGl50oZi53hqyzhwjNKZ3mIr2zg/TAJZoapKvc14cthH17zKSSJrqI/NgBStRmZhBBkXcwfu1CANw==",
+      "dependencies": {
+        "@comunica/bus-rdf-parse-html": "^2.10.0",
+        "@comunica/core": "^2.10.0",
+        "rdfa-streaming-parser": "^2.0.1"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-parse-html-script": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html-script/-/actor-rdf-parse-html-script-2.10.0.tgz",
+      "integrity": "sha512-7XYqWchDquWnBLjG7rmmY+tdE81UZ8fPCU0Hn+vI39/MikNOpaiyr/ZYFqhogWFa9SkjmH0a7idVUzmjiwKRZQ==",
+      "dependencies": {
+        "@comunica/bus-rdf-parse": "^2.10.0",
+        "@comunica/bus-rdf-parse-html": "^2.10.0",
+        "@comunica/context-entries": "^2.10.0",
+        "@comunica/core": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "@rdfjs/types": "*",
+        "readable-stream": "^4.4.2",
+        "relative-to-absolute-iri": "^1.0.7"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-parse-jsonld": {
+      "version": "2.10.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-jsonld/-/actor-rdf-parse-jsonld-2.10.2.tgz",
+      "integrity": "sha512-K4fvD0zMU22KkQCqIFVT5Oy2FREEZ9CAo9u6kOcsMxEvg9aHGIM6hkaXR8I+1JCx1mDuEj3zQ8joR4tQh8fYCw==",
+      "dependencies": {
+        "@comunica/bus-http": "^2.10.2",
+        "@comunica/bus-rdf-parse": "^2.10.0",
+        "@comunica/context-entries": "^2.10.0",
+        "@comunica/core": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "jsonld-context-parser": "^2.2.2",
+        "jsonld-streaming-parser": "^3.0.1",
+        "stream-to-string": "^1.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-parse-n3": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-n3/-/actor-rdf-parse-n3-2.10.0.tgz",
+      "integrity": "sha512-o1MAbwJxW4Br2WCZdhFoRmAiOP4mfogeQqJ4nqlsOkoMtQ45EvLHsotb3Kqhuk5V+vsTxyK5v/a4zylGtcU7VQ==",
+      "dependencies": {
+        "@comunica/bus-rdf-parse": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "n3": "^1.17.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-parse-rdfxml": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-rdfxml/-/actor-rdf-parse-rdfxml-2.10.0.tgz",
+      "integrity": "sha512-HoJN52shXY3cvYtsS0cpin9KXpW3L7g1leebyCRSqnlnHdJv5D6G0Ep8vyt2xhquKNbOQ7LnP5VhiDiqz73XDg==",
+      "dependencies": {
+        "@comunica/bus-rdf-parse": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "rdfxml-streaming-parser": "^2.2.3"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-parse-shaclc": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-shaclc/-/actor-rdf-parse-shaclc-2.10.0.tgz",
+      "integrity": "sha512-i6tmuZuS+RtDiSXpQc3s/PxtCqwIguo4ANmVB20PK4VWgQgBwoPG7LlNcJ0xmuH/3Bv6C2Agn18PLF6dZX+fKw==",
+      "dependencies": {
+        "@comunica/bus-rdf-parse": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.8.1",
+        "readable-stream": "^4.4.2",
+        "shaclc-parse": "^1.4.0",
+        "stream-to-string": "^1.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-parse-xml-rdfa": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-xml-rdfa/-/actor-rdf-parse-xml-rdfa-2.10.0.tgz",
+      "integrity": "sha512-68r/6B/fEyA1/OYleVuaPq47J+g4xJcJijpdL1wEj7CqjV+Xa+sDWRpNCyLcD/e1Y/g9UQmLz0ZnSpR00PFddA==",
+      "dependencies": {
+        "@comunica/bus-rdf-parse": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "rdfa-streaming-parser": "^2.0.1"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-resolve-hypermedia-links-next": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-hypermedia-links-next/-/actor-rdf-resolve-hypermedia-links-next-2.10.0.tgz",
+      "integrity": "sha512-SpW46Tx8ksAxotGK2UEpvGcYjKwxB0x2KnbGmKHvo59embRjcUL/bmq3uHqZe7UwfynR2wDaRzMdVVSQccWSyA==",
+      "dependencies": {
+        "@comunica/bus-rdf-resolve-hypermedia-links": "^2.10.0",
+        "@comunica/core": "^2.10.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-resolve-hypermedia-links-queue-fifo": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-hypermedia-links-queue-fifo/-/actor-rdf-resolve-hypermedia-links-queue-fifo-2.10.0.tgz",
+      "integrity": "sha512-Hh53Ts6z6MxKXhZZxgpXfc1hgNzIX/xbA9mD2Au7ZfAa5V5j8zPaVVKe06sxILQBTPMsFh1idP3vIqRwRXpsvg==",
+      "dependencies": {
+        "@comunica/bus-rdf-resolve-hypermedia-links": "^2.10.0",
+        "@comunica/bus-rdf-resolve-hypermedia-links-queue": "^2.10.0",
+        "@comunica/core": "^2.10.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-resolve-hypermedia-none": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-hypermedia-none/-/actor-rdf-resolve-hypermedia-none-2.10.0.tgz",
+      "integrity": "sha512-C4sJ0QJetq3QxsRkYstK5YXRYDGkcVTfyBOFUMYj7PbVakapnl8qPZkVL7VPMLVLVOfyBQHTT43Yp6Nl8VvmSA==",
+      "dependencies": {
+        "@comunica/actor-rdf-resolve-quad-pattern-rdfjs-source": "^2.10.0",
+        "@comunica/bus-rdf-resolve-hypermedia": "^2.10.0",
+        "rdf-store-stream": "^2.0.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-resolve-hypermedia-qpf": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-hypermedia-qpf/-/actor-rdf-resolve-hypermedia-qpf-2.10.0.tgz",
+      "integrity": "sha512-1iP9xD72bxFBLpbfC7Ev0Xoc+0rwusPFdnoYbEtqMHRfiM0h3nNrsSxyzdGJMAZaJeQzmBZIEiwR5pbo9qpmaQ==",
+      "dependencies": {
+        "@comunica/actor-rdf-metadata-extract-hydra-controls": "^2.10.0",
+        "@comunica/bus-dereference-rdf": "^2.10.0",
+        "@comunica/bus-rdf-metadata": "^2.10.0",
+        "@comunica/bus-rdf-metadata-extract": "^2.10.0",
+        "@comunica/bus-rdf-resolve-hypermedia": "^2.10.0",
+        "@comunica/bus-rdf-resolve-quad-pattern": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.8.1",
+        "rdf-data-factory": "^1.1.1",
+        "rdf-string": "^1.6.1",
+        "rdf-terms": "^1.11.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-resolve-hypermedia-sparql": {
+      "version": "2.10.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-hypermedia-sparql/-/actor-rdf-resolve-hypermedia-sparql-2.10.2.tgz",
+      "integrity": "sha512-UFsTuzHvjK/XhRGqfHr3WAVr+iBv6XTuU1fV9EuOaB+odclQ+H6TGtmW6/38CSufj86Y691VBXMk29zdWfrmGA==",
+      "dependencies": {
+        "@comunica/bindings-factory": "^2.10.1",
+        "@comunica/bus-http": "^2.10.2",
+        "@comunica/bus-rdf-resolve-hypermedia": "^2.10.0",
+        "@comunica/bus-rdf-resolve-quad-pattern": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.8.1",
+        "fetch-sparql-endpoint": "^4.0.0",
+        "lru-cache": "^10.0.0",
+        "rdf-data-factory": "^1.1.1",
+        "rdf-terms": "^1.11.0",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-resolve-hypermedia-sparql/node_modules/lru-cache": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.2.0.tgz",
+      "integrity": "sha512-2bIM8x+VAf6JT4bKAljS1qUWgMsqZRPGJS6FSahIMPVvctcNhyVp7AJu7quxOW9jwkryBReKZY5tY5JYv2n/7Q==",
+      "engines": {
+        "node": "14 || >=16.14"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-resolve-quad-pattern-federated": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-quad-pattern-federated/-/actor-rdf-resolve-quad-pattern-federated-2.10.1.tgz",
+      "integrity": "sha512-OBRTTUWkXKa0ibDzcYLG7aKf3BfQp2j75xm65brRvwstNLmye9ZEq1PrNhbP5UDqQQeCgzPBrb0eGC8Vxek2RA==",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^2.10.1",
+        "@comunica/bus-rdf-metadata-accumulate": "^2.10.0",
+        "@comunica/bus-rdf-resolve-quad-pattern": "^2.10.0",
+        "@comunica/context-entries": "^2.10.0",
+        "@comunica/core": "^2.10.0",
+        "@comunica/data-factory": "^2.7.0",
+        "@comunica/metadata": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.8.1",
+        "rdf-data-factory": "^1.1.1",
+        "rdf-terms": "^1.11.0",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-resolve-quad-pattern-hypermedia": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-quad-pattern-hypermedia/-/actor-rdf-resolve-quad-pattern-hypermedia-2.10.1.tgz",
+      "integrity": "sha512-XkJOYu0bizWHsvgiaGyNAnRZsqv2risREK5SY14VCMXDYqmOWJLDppveGEUZAoEKEJuo4ZLDlP2gLDGzc0krxQ==",
+      "dependencies": {
+        "@comunica/bus-dereference-rdf": "^2.10.0",
+        "@comunica/bus-http-invalidate": "^2.10.0",
+        "@comunica/bus-query-operation": "^2.10.1",
+        "@comunica/bus-rdf-metadata": "^2.10.0",
+        "@comunica/bus-rdf-metadata-accumulate": "^2.10.0",
+        "@comunica/bus-rdf-metadata-extract": "^2.10.0",
+        "@comunica/bus-rdf-resolve-hypermedia": "^2.10.0",
+        "@comunica/bus-rdf-resolve-hypermedia-links": "^2.10.0",
+        "@comunica/bus-rdf-resolve-hypermedia-links-queue": "^2.10.0",
+        "@comunica/bus-rdf-resolve-quad-pattern": "^2.10.0",
+        "@comunica/context-entries": "^2.10.0",
+        "@comunica/core": "^2.10.0",
+        "@comunica/metadata": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.8.1",
+        "lru-cache": "^10.0.0",
+        "rdf-data-factory": "^1.1.2",
+        "rdf-streaming-store": "^1.1.0",
+        "readable-stream": "^4.4.2",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-resolve-quad-pattern-hypermedia/node_modules/lru-cache": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.2.0.tgz",
+      "integrity": "sha512-2bIM8x+VAf6JT4bKAljS1qUWgMsqZRPGJS6FSahIMPVvctcNhyVp7AJu7quxOW9jwkryBReKZY5tY5JYv2n/7Q==",
+      "engines": {
+        "node": "14 || >=16.14"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-resolve-quad-pattern-rdfjs-source": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-quad-pattern-rdfjs-source/-/actor-rdf-resolve-quad-pattern-rdfjs-source-2.10.0.tgz",
+      "integrity": "sha512-d6AlrngvZaVgoiiyMhkf6uiYaFZZdn/UZLo0FhZ++or1NZXo5KxK4UMgdiIygvPEiuuVzy0W1djHgOQ1rgh50g==",
+      "dependencies": {
+        "@comunica/bus-rdf-resolve-quad-pattern": "^2.10.0",
+        "@comunica/core": "^2.10.0",
+        "@comunica/metadata": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.8.1",
+        "rdf-data-factory": "^1.1.2",
+        "rdf-terms": "^1.11.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-resolve-quad-pattern-string-source": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-quad-pattern-string-source/-/actor-rdf-resolve-quad-pattern-string-source-2.10.0.tgz",
+      "integrity": "sha512-v6QOBtXTXrDUZRHocrm2OYCsxGpyTScka/n85cewCcInqVGJP9J6zpdwetzvIy7wVJkac7JQabd96OEyDMK3sg==",
+      "dependencies": {
+        "@comunica/bus-rdf-parse": "^2.10.0",
+        "@comunica/bus-rdf-resolve-quad-pattern": "^2.10.0",
+        "@comunica/context-entries": "^2.10.0",
+        "@comunica/core": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "@rdfjs/types": "*",
+        "lru-cache": "^10.0.0",
+        "rdf-store-stream": "^2.0.0",
+        "readable-stream": "^4.4.2"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-resolve-quad-pattern-string-source/node_modules/lru-cache": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.2.0.tgz",
+      "integrity": "sha512-2bIM8x+VAf6JT4bKAljS1qUWgMsqZRPGJS6FSahIMPVvctcNhyVp7AJu7quxOW9jwkryBReKZY5tY5JYv2n/7Q==",
+      "engines": {
+        "node": "14 || >=16.14"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-serialize-jsonld": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-serialize-jsonld/-/actor-rdf-serialize-jsonld-2.10.0.tgz",
+      "integrity": "sha512-u1M5N7BSrkhS461fV6QXKMh6TnvpoEiSHPru7wJg1kGqR9q3reuQeKLf/U23JDYb1kom8uU3R7aBpDIjgVc49Q==",
+      "dependencies": {
+        "@comunica/bus-rdf-serialize": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "jsonld-streaming-serializer": "^2.1.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-serialize-n3": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-serialize-n3/-/actor-rdf-serialize-n3-2.10.0.tgz",
+      "integrity": "sha512-CoDktUI3YQuI7UBV+fQOdKl+5XjBx0XTOF9XxEDiNg5nwndEmDvq6C23fSHfkqX3/xDlnsuS/YysHAqXCrYoiA==",
+      "dependencies": {
+        "@comunica/bus-rdf-serialize": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "n3": "^1.17.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-serialize-shaclc": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-serialize-shaclc/-/actor-rdf-serialize-shaclc-2.10.0.tgz",
+      "integrity": "sha512-gp4bu4+aPtMk4bavXP27uD9X9bpa2F5u6/JtsaX2qwcqVI0x1tkVQOkm2RkUhafcHNj0Fz6lQ3aXmRIAQvaefg==",
+      "dependencies": {
+        "@comunica/bus-rdf-serialize": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "arrayify-stream": "^2.0.1",
+        "readable-stream": "^4.4.2",
+        "shaclc-write": "^1.4.2"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-update-hypermedia-patch-sparql-update": {
+      "version": "2.10.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-update-hypermedia-patch-sparql-update/-/actor-rdf-update-hypermedia-patch-sparql-update-2.10.2.tgz",
+      "integrity": "sha512-z/fOzYlA5fPtauTUISYhCWMKtEpkvKkSZIdvcgeGvetLnvw4fytfVHdtPhirZYmPya10GCeTG7m2iHvK53lOsQ==",
+      "dependencies": {
+        "@comunica/bus-http": "^2.10.2",
+        "@comunica/bus-rdf-update-hypermedia": "^2.10.2",
+        "@comunica/bus-rdf-update-quads": "^2.10.2",
+        "@comunica/core": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.8.1",
+        "cross-fetch": "^4.0.0",
+        "rdf-string-ttl": "^1.3.2",
+        "readable-stream": "^4.4.2"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-update-hypermedia-put-ldp": {
+      "version": "2.10.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-update-hypermedia-put-ldp/-/actor-rdf-update-hypermedia-put-ldp-2.10.2.tgz",
+      "integrity": "sha512-Tof/mU0Lkt7HP3SwHXODczxvAFelWzAHdP+ap4Upr47K6Zg5GRPwJv//2AcPvT3p42Li6wuMz/4nh/A3pcnCKA==",
+      "dependencies": {
+        "@comunica/bus-http": "^2.10.2",
+        "@comunica/bus-rdf-serialize": "^2.10.0",
+        "@comunica/bus-rdf-update-hypermedia": "^2.10.2",
+        "@comunica/bus-rdf-update-quads": "^2.10.2",
+        "@comunica/core": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.8.1",
+        "cross-fetch": "^4.0.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-update-hypermedia-sparql": {
+      "version": "2.10.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-update-hypermedia-sparql/-/actor-rdf-update-hypermedia-sparql-2.10.2.tgz",
+      "integrity": "sha512-uw1NIAoxuAechsjTQ6b53XpGOMx3Mp5uEL5LtUwNC6COJE6tzWH8wG54Dwj+0VNxsgqsSircKu2xwGl1uOsOPg==",
+      "dependencies": {
+        "@comunica/bus-http": "^2.10.2",
+        "@comunica/bus-rdf-update-hypermedia": "^2.10.2",
+        "@comunica/bus-rdf-update-quads": "^2.10.2",
+        "@comunica/core": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.8.1",
+        "fetch-sparql-endpoint": "^4.0.0",
+        "rdf-string-ttl": "^1.3.2",
+        "stream-to-string": "^1.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-update-quads-hypermedia": {
+      "version": "2.10.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-update-quads-hypermedia/-/actor-rdf-update-quads-hypermedia-2.10.2.tgz",
+      "integrity": "sha512-kzGfDv0PqcOIIULJLG8jtA/dOcrNUodu98J08ruSuYQBbnFgAZ07MG1TkWhEI/AM6D0w7hXkgQaC1sGWn4gVmA==",
+      "dependencies": {
+        "@comunica/bus-dereference-rdf": "^2.10.0",
+        "@comunica/bus-http-invalidate": "^2.10.0",
+        "@comunica/bus-rdf-metadata": "^2.10.0",
+        "@comunica/bus-rdf-metadata-extract": "^2.10.0",
+        "@comunica/bus-rdf-update-hypermedia": "^2.10.2",
+        "@comunica/bus-rdf-update-quads": "^2.10.2",
+        "@comunica/core": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "lru-cache": "^10.0.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-update-quads-hypermedia/node_modules/lru-cache": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.2.0.tgz",
+      "integrity": "sha512-2bIM8x+VAf6JT4bKAljS1qUWgMsqZRPGJS6FSahIMPVvctcNhyVp7AJu7quxOW9jwkryBReKZY5tY5JYv2n/7Q==",
+      "engines": {
+        "node": "14 || >=16.14"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-update-quads-rdfjs-store": {
+      "version": "2.10.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-update-quads-rdfjs-store/-/actor-rdf-update-quads-rdfjs-store-2.10.2.tgz",
+      "integrity": "sha512-anX3SovvY2H8KwuWu8G9EqtITmCsz12jfqunNn5Efcch/bm4HyHTC1GThx77m6qpCdg4OMx8TLhNrH1II1UM1w==",
+      "dependencies": {
+        "@comunica/bus-rdf-update-quads": "^2.10.2",
+        "@comunica/core": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.8.1",
+        "rdf-data-factory": "^1.1.1",
+        "rdf-string": "^1.6.1"
+      }
+    },
+    "node_modules/@comunica/bindings-factory": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@comunica/bindings-factory/-/bindings-factory-2.10.1.tgz",
+      "integrity": "sha512-AUD3VWlCYljgk5jfaMejSIL9CiX3aV/cAn314e/dYP/rrnVgachcCwyaD8hKHWTBHDs5rcGxr/iwruBOfsERvQ==",
+      "dependencies": {
+        "@rdfjs/types": "*",
+        "immutable": "^4.1.0",
+        "rdf-data-factory": "^1.1.1",
+        "rdf-string": "^1.6.1"
+      }
+    },
+    "node_modules/@comunica/bus-context-preprocess": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-context-preprocess/-/bus-context-preprocess-2.10.0.tgz",
+      "integrity": "sha512-eJ5CkzbnmxB9fkr2F05jnnjcaowp+yxd0+pAtvx5MLl2Kpx3nWLqHPcl4/EVVDPD+i0TEkq4AXQ1BD9BMuXK0A==",
+      "dependencies": {
+        "@comunica/core": "^2.10.0",
+        "@comunica/types": "^2.10.0"
+      }
+    },
+    "node_modules/@comunica/bus-dereference": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-dereference/-/bus-dereference-2.10.0.tgz",
+      "integrity": "sha512-nWyQXiH7zbiPTVttWVKJHykhV4IuahfhfUwPx3Op+cVsK489Su84dnGeSmPkxTAFFuxe6wU6ZEH4i7PDu48YvQ==",
+      "dependencies": {
+        "@comunica/actor-abstract-mediatyped": "^2.10.0",
+        "@comunica/actor-abstract-parse": "^2.10.0",
+        "@comunica/context-entries": "^2.10.0",
+        "@comunica/core": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "readable-stream": "^4.4.2"
+      }
+    },
+    "node_modules/@comunica/bus-dereference-rdf": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-dereference-rdf/-/bus-dereference-rdf-2.10.0.tgz",
+      "integrity": "sha512-WY/wPmFpO76wwJ2D5Aus43ZbYnBRLvQ0EOp4yywO0lBiq6F0JisjCVCM4EtWouOEAAfqEoIjHXGyC3gPWqm+SQ==",
+      "dependencies": {
+        "@comunica/bus-dereference": "^2.10.0",
+        "@comunica/bus-rdf-parse": "^2.10.0",
+        "@comunica/core": "^2.10.0",
+        "@rdfjs/types": "*"
+      }
+    },
+    "node_modules/@comunica/bus-hash-bindings": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-hash-bindings/-/bus-hash-bindings-2.10.0.tgz",
+      "integrity": "sha512-EdzIUgpSWMtFVxEJSesuQpMkfgznDap+U0F9epotxXc20Gg/qjTzs1gF6NkpDpaidQ7cFlV16vdbdfi8uiZ+mQ==",
+      "dependencies": {
+        "@comunica/core": "^2.10.0",
+        "@comunica/types": "^2.10.0"
+      }
+    },
+    "node_modules/@comunica/bus-http": {
+      "version": "2.10.2",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-http/-/bus-http-2.10.2.tgz",
+      "integrity": "sha512-MAYRF6uEBAuJ9dCPW2Uyne7w3lNwXFXKfa14XuPG5DFTDpgo/Z2pWupPrBsA1eIWMNJ6WOG6QyEv4rllSIBqlg==",
+      "dependencies": {
+        "@comunica/core": "^2.10.0",
+        "@smessie/readable-web-to-node-stream": "^3.0.3",
+        "is-stream": "^2.0.1",
+        "readable-stream-node-to-web": "^1.0.1",
+        "web-streams-ponyfill": "^1.4.2"
+      }
+    },
+    "node_modules/@comunica/bus-http-invalidate": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-http-invalidate/-/bus-http-invalidate-2.10.0.tgz",
+      "integrity": "sha512-9DevRUzuCOfHFtsryIvTU6rOz6vMbnuDzerloBoNsLFVzQCU4wPNZbxiOn0+GMDXxw7M3KgYd+KFxI2kGObVWA==",
+      "dependencies": {
+        "@comunica/core": "^2.10.0"
+      }
+    },
+    "node_modules/@comunica/bus-init": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-init/-/bus-init-2.10.0.tgz",
+      "integrity": "sha512-hJejHa8sLVhQLFlduCVnhOd5aW3FCEz8wmWjyeLI3kiHFaQibnGVMhUuuNRX5f8bnnPuTdEiHc1nnYHuSi+j8A==",
+      "dependencies": {
+        "@comunica/core": "^2.10.0",
+        "readable-stream": "^4.4.2"
+      }
+    },
+    "node_modules/@comunica/bus-optimize-query-operation": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-optimize-query-operation/-/bus-optimize-query-operation-2.10.0.tgz",
+      "integrity": "sha512-qawKJprbVc+dfjBgVzV45UEo+jZBzY3dRo0a8UkXSvgSWPcX18SGrURl2VL4sZZSAyXQBMrGUwH2eUD8l26ZJQ==",
+      "dependencies": {
+        "@comunica/core": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/bus-query-operation": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-query-operation/-/bus-query-operation-2.10.1.tgz",
+      "integrity": "sha512-PoUSJeKaMZtZu+ZtB+5ABjPOiW1YjxOdLE1N5znxX2oiDKCQHmAXVaVkbVx1jPDLGYFNcOlOSzpRMqLQ/L4JIw==",
+      "dependencies": {
+        "@comunica/bindings-factory": "^2.10.1",
+        "@comunica/context-entries": "^2.10.0",
+        "@comunica/core": "^2.10.0",
+        "@comunica/data-factory": "^2.7.0",
+        "@comunica/types": "^2.10.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.8.1",
+        "rdf-string": "^1.6.1",
+        "rdf-terms": "^1.11.0",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/bus-query-parse": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-query-parse/-/bus-query-parse-2.10.0.tgz",
+      "integrity": "sha512-1LynxACgCYTuBH/JMRG/IGaWtTVwr2O8wxOosCId2W3BDW9nf2DSCyOdnxnCSMSKfnLFWiaVuKybn24OLXW2dQ==",
+      "dependencies": {
+        "@comunica/core": "^2.10.0",
+        "@rdfjs/types": "*",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/bus-query-result-serialize": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-query-result-serialize/-/bus-query-result-serialize-2.10.0.tgz",
+      "integrity": "sha512-9P5KUzmXvjtLbd44UVxYNB0yqAHx7molBUc7aysUQ3pbIcP/A57GXzAfiKueeiZ9cVRRG/BGsVoDGVj59tGWNg==",
+      "dependencies": {
+        "@comunica/actor-abstract-mediatyped": "^2.10.0",
+        "@comunica/core": "^2.10.0",
+        "@comunica/types": "^2.10.0"
+      }
+    },
+    "node_modules/@comunica/bus-rdf-join": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-join/-/bus-rdf-join-2.10.1.tgz",
+      "integrity": "sha512-pPFoJVHY5p931jIKt+9sqRCGiuuf8yFqrlOOAd3un72cwuyhwNHvn52xwvcPlNUAySz/kDmW+U0syflqI6VdAw==",
+      "dependencies": {
+        "@comunica/bus-query-operation": "^2.10.1",
+        "@comunica/bus-rdf-join-selectivity": "^2.10.0",
+        "@comunica/context-entries": "^2.10.0",
+        "@comunica/core": "^2.10.0",
+        "@comunica/mediatortype-join-coefficients": "^2.10.0",
+        "@comunica/metadata": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "@rdfjs/types": "*",
+        "rdf-data-factory": "^1.1.1",
+        "rdf-string": "^1.6.1"
+      }
+    },
+    "node_modules/@comunica/bus-rdf-join-entries-sort": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-join-entries-sort/-/bus-rdf-join-entries-sort-2.10.0.tgz",
+      "integrity": "sha512-17FQrdYtzjY84OI/ZvipJKD0ei3IySmsWwaGC9sIJn+1W4LBVKudTu5S0tzGTKTb0URhS4mrCliUBzyINtIZMQ==",
+      "dependencies": {
+        "@comunica/core": "^2.10.0",
+        "@comunica/types": "^2.10.0"
+      }
+    },
+    "node_modules/@comunica/bus-rdf-join-selectivity": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-join-selectivity/-/bus-rdf-join-selectivity-2.10.0.tgz",
+      "integrity": "sha512-YjoygSiH6r4SAYqz6gpvUql2vnznPVE62IsWqYnjFWeH1kBsxO5yEOO01s2FfN3jLcfsytTyG7VNTCN788YbaA==",
+      "dependencies": {
+        "@comunica/core": "^2.10.0",
+        "@comunica/mediatortype-accuracy": "^2.10.0",
+        "@comunica/types": "^2.10.0"
+      }
+    },
+    "node_modules/@comunica/bus-rdf-metadata": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-metadata/-/bus-rdf-metadata-2.10.0.tgz",
+      "integrity": "sha512-LRUnHVqIzyUlmPKPNAYOusCF53iN8KEX7l/VinlA7NH3XBLhTkFoth26MVqIVtjtdH0hVfUVpkwy2kFEJpGldw==",
+      "dependencies": {
+        "@comunica/core": "^2.10.0",
+        "@rdfjs/types": "*"
+      }
+    },
+    "node_modules/@comunica/bus-rdf-metadata-accumulate": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-metadata-accumulate/-/bus-rdf-metadata-accumulate-2.10.0.tgz",
+      "integrity": "sha512-XG/3s4a3yGpYt4H+sn9T2zTaUxLG+37dmhRhXv2cBmR4gaCXkglERPaOrQygHldEF+4ITF3RmXHCgANsQ1AwQg==",
+      "dependencies": {
+        "@comunica/core": "^2.10.0",
+        "@comunica/types": "^2.10.0"
+      }
+    },
+    "node_modules/@comunica/bus-rdf-metadata-extract": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-metadata-extract/-/bus-rdf-metadata-extract-2.10.0.tgz",
+      "integrity": "sha512-KcMZh+7kHjdCIMkLFki99tQH1arVp/evVnk0BGXfWd+ca3eCLrr42tb1tGfN2JkaCSxgtzWO4DRZcSzJ4sI2dQ==",
+      "dependencies": {
+        "@comunica/core": "^2.10.0",
+        "@rdfjs/types": "*"
+      }
+    },
+    "node_modules/@comunica/bus-rdf-parse": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-parse/-/bus-rdf-parse-2.10.0.tgz",
+      "integrity": "sha512-EgCMZACfTG/+mayQpExWt0HoBT32BBVC1aS1lC43fXKBTxJ8kYrSrorVUuMACoh4dQVGTb+7j1j4K0hGNVzXGA==",
+      "dependencies": {
+        "@comunica/actor-abstract-mediatyped": "^2.10.0",
+        "@comunica/actor-abstract-parse": "^2.10.0",
+        "@comunica/core": "^2.10.0",
+        "@rdfjs/types": "*"
+      }
+    },
+    "node_modules/@comunica/bus-rdf-parse-html": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-parse-html/-/bus-rdf-parse-html-2.10.0.tgz",
+      "integrity": "sha512-RZliz4TtKP63QggoohGuIkGb6lq0BoYJ4aztKtGldWtPAVP/pdEvlDpiZWLB/j19g7S2aDLNY/lJtZ5efM1tHQ==",
+      "dependencies": {
+        "@comunica/core": "^2.10.0",
+        "@rdfjs/types": "*"
+      }
+    },
+    "node_modules/@comunica/bus-rdf-resolve-hypermedia": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-resolve-hypermedia/-/bus-rdf-resolve-hypermedia-2.10.0.tgz",
+      "integrity": "sha512-DjCoAg62pPzEOH5gKM9gaL4CVUmhBsmyOzao0tRu20G7L6RnTIFtRaOwMN2z+2uC7AkJRHZY12bPUb+yM8V0UQ==",
+      "dependencies": {
+        "@comunica/bus-rdf-resolve-quad-pattern": "^2.10.0",
+        "@comunica/core": "^2.10.0",
+        "@rdfjs/types": "*"
+      }
+    },
+    "node_modules/@comunica/bus-rdf-resolve-hypermedia-links": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-resolve-hypermedia-links/-/bus-rdf-resolve-hypermedia-links-2.10.0.tgz",
+      "integrity": "sha512-Mcz6bUdZySLK2om0cMt86n5TOThZOTpEFq2M42n7YAE3LL2KMnMDdhkaOC6SyY4tS0HGAuhce21Uq+Gz8Veq2g==",
+      "dependencies": {
+        "@comunica/core": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "@rdfjs/types": "*"
+      }
+    },
+    "node_modules/@comunica/bus-rdf-resolve-hypermedia-links-queue": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-resolve-hypermedia-links-queue/-/bus-rdf-resolve-hypermedia-links-queue-2.10.0.tgz",
+      "integrity": "sha512-f9amJk7ikktRfOoRnwag1KMTuo9v+PiDEVQA0dijl+jhcispKdjG6XK0MdZ1KSEmtUWejjS6nMRGvfJdM37eog==",
+      "dependencies": {
+        "@comunica/bus-rdf-resolve-hypermedia-links": "^2.10.0",
+        "@comunica/core": "^2.10.0"
+      }
+    },
+    "node_modules/@comunica/bus-rdf-resolve-quad-pattern": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-resolve-quad-pattern/-/bus-rdf-resolve-quad-pattern-2.10.0.tgz",
+      "integrity": "sha512-JEI4DqSprGmrbfmiIwc8PbS+HCoxXwmMtp7gDpoB1HyYKIHzzu9DOIiwmYEDRO5dwV+uTwaYKZz/mUPm2U6EEg==",
+      "dependencies": {
+        "@comunica/context-entries": "^2.10.0",
+        "@comunica/core": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.8.1",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/bus-rdf-serialize": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-serialize/-/bus-rdf-serialize-2.10.0.tgz",
+      "integrity": "sha512-AmbN9MUgw6B6AfrIqR1u7PWHZFgbJz+j1SFJVtnHQ51hEpG+Ig9nNG2IWjHOsFK0xBBQ/wXgNmt/cufEMRM1SQ==",
+      "dependencies": {
+        "@comunica/actor-abstract-mediatyped": "^2.10.0",
+        "@comunica/core": "^2.10.0",
+        "@rdfjs/types": "*"
+      }
+    },
+    "node_modules/@comunica/bus-rdf-update-hypermedia": {
+      "version": "2.10.2",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-update-hypermedia/-/bus-rdf-update-hypermedia-2.10.2.tgz",
+      "integrity": "sha512-GbRMxXN4kx+4UPsnGxWjyn770m675yy2gWK/xy/5qQIxxRTcuGk4wm/994FZQXpwLX1E0xJ+YKxMgXTIlEWmQA==",
+      "dependencies": {
+        "@comunica/bus-rdf-update-quads": "^2.10.2",
+        "@comunica/core": "^2.10.0"
+      }
+    },
+    "node_modules/@comunica/bus-rdf-update-quads": {
+      "version": "2.10.2",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-update-quads/-/bus-rdf-update-quads-2.10.2.tgz",
+      "integrity": "sha512-+iVpAHps8ytGq8AZF4xTZbLyskS40JPn64MO+OAuYovqXLlezp6vh9eJ5qETuP9NP+BpZDk3nOU3Ky3fb0QCUw==",
+      "dependencies": {
+        "@comunica/actor-rdf-resolve-quad-pattern-federated": "^2.10.1",
+        "@comunica/bus-http": "^2.10.2",
+        "@comunica/context-entries": "^2.10.0",
+        "@comunica/core": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.8.1",
+        "stream-to-string": "^1.2.0"
+      }
+    },
+    "node_modules/@comunica/config-query-sparql": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@comunica/config-query-sparql/-/config-query-sparql-2.7.0.tgz",
+      "integrity": "sha512-rMnFgT7cz9+0z7wV4OzIMY5qM9/Z0mTGrR8y2JokoHyyTcBGOSajFmy61XCSLMCsLLG8qDXsJ4ClCCky3TGfqA=="
+    },
+    "node_modules/@comunica/context-entries": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/context-entries/-/context-entries-2.10.0.tgz",
+      "integrity": "sha512-lmCYCcXxW8C6ecFH2whZCt31NT1ejb0P/sbytK7f4ctyA06Q8iYFEcYE4eWOXMdpfkwkcnz31x9XL77OGeSC2Q==",
+      "dependencies": {
+        "@comunica/core": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "@rdfjs/types": "*",
+        "jsonld-context-parser": "^2.2.2",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@comunica/core": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.10.0.tgz",
+      "integrity": "sha512-onsGs2iKHUPRxxMOdx42vdxslk8q9FQZdRjQtHJ6SGiCpJwIL9ciBgPIOl2RL2YfzXHemr/0umeNOppRDcWhJA==",
+      "dependencies": {
+        "@comunica/types": "^2.10.0",
+        "immutable": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
+    "node_modules/@comunica/data-factory": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@comunica/data-factory/-/data-factory-2.7.0.tgz",
+      "integrity": "sha512-dSTzrR1w9SzAWx70ZXKXHUC8f0leUolLZ9TOhGjFhhsBMJ9Pbo0g6vHV8txX5FViShngrg9QNKhsHeQnMk5z6Q==",
+      "dependencies": {
+        "@rdfjs/types": "*"
+      }
+    },
+    "node_modules/@comunica/expression-evaluator": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/expression-evaluator/-/expression-evaluator-2.10.0.tgz",
+      "integrity": "sha512-gSfiVSAE+SaxpXq3jT5OnyZd+sD9KFaWtTiKT1tDDs8lD7Jj68aRP7VoEhvKwPwRlUx0aoaXUL2MYtV6JsXRbg==",
+      "dependencies": {
+        "@rdfjs/types": "*",
+        "@types/spark-md5": "^3.0.2",
+        "@types/uuid": "^9.0.0",
+        "bignumber.js": "^9.0.1",
+        "hash.js": "^1.1.7",
+        "lru-cache": "^10.0.0",
+        "rdf-data-factory": "^1.1.2",
+        "rdf-string": "^1.6.3",
+        "relative-to-absolute-iri": "^1.0.6",
+        "spark-md5": "^3.0.1",
+        "sparqlalgebrajs": "^4.2.0",
+        "uuid": "^9.0.0"
+      }
+    },
+    "node_modules/@comunica/expression-evaluator/node_modules/lru-cache": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.2.0.tgz",
+      "integrity": "sha512-2bIM8x+VAf6JT4bKAljS1qUWgMsqZRPGJS6FSahIMPVvctcNhyVp7AJu7quxOW9jwkryBReKZY5tY5JYv2n/7Q==",
+      "engines": {
+        "node": "14 || >=16.14"
+      }
+    },
+    "node_modules/@comunica/logger-pretty": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/logger-pretty/-/logger-pretty-2.10.0.tgz",
+      "integrity": "sha512-JXkeM5HnbyTPnQTf5/ugRPL9R+vXT7b/hRVYzYmhAGCjkCNL7NJPTBbIgxmZHqZ+UGxprotrvmDQtwHmVA+Ddw==",
+      "dependencies": {
+        "@comunica/types": "^2.10.0",
+        "object-inspect": "^1.12.2",
+        "process": "^0.11.10"
+      }
+    },
+    "node_modules/@comunica/logger-void": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/logger-void/-/logger-void-2.10.0.tgz",
+      "integrity": "sha512-GFJh9hV8rIC9yXAuLGGKjQRVs8IOQOINBbaTNO+FJUWWWHlo5pDEKAoGYuysz5TBGoT3Lexz8bMfdkuHMa3uIQ==",
+      "dependencies": {
+        "@comunica/types": "^2.10.0"
+      }
+    },
+    "node_modules/@comunica/mediator-all": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/mediator-all/-/mediator-all-2.10.0.tgz",
+      "integrity": "sha512-y1+A+sIW462G8iPzi6BSPIb4I9iy08ZruM2Thf1or6sytwLKro7E2RYjS6IdupwfFYafXXCeT85+lrJgTKERhQ==",
+      "dependencies": {
+        "@comunica/core": "^2.10.0"
+      }
+    },
+    "node_modules/@comunica/mediator-combine-pipeline": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/mediator-combine-pipeline/-/mediator-combine-pipeline-2.10.0.tgz",
+      "integrity": "sha512-j7+/oUlbhKB4Rq6g9oNKU+e9cQL8U9z8tAUNhoXUSHajcr4huj0t1+riaOD109/DRWhV793ILhBDzgiZbHd7DA==",
+      "dependencies": {
+        "@comunica/core": "^2.10.0",
+        "@comunica/types": "^2.10.0"
+      }
+    },
+    "node_modules/@comunica/mediator-combine-union": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/mediator-combine-union/-/mediator-combine-union-2.10.0.tgz",
+      "integrity": "sha512-QbP4zP1i6nMDZ8teC0RoTz5E8pOpxDhWPBr1ylb2jzPUjPpMgrnbHYTondlN0Oau3SMEehItojg/LYDtPOP/GQ==",
+      "dependencies": {
+        "@comunica/core": "^2.10.0"
+      }
+    },
+    "node_modules/@comunica/mediator-join-coefficients-fixed": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@comunica/mediator-join-coefficients-fixed/-/mediator-join-coefficients-fixed-2.10.1.tgz",
+      "integrity": "sha512-HRvc0e8QDnR3sbRMMCyx9ILFA6KiUxHEqDOpt7BV3kFMWWIpBavFDwPUjLBG6sRA8o0CFu1+oVVh5fAFYZIxzQ==",
+      "dependencies": {
+        "@comunica/bus-rdf-join": "^2.10.1",
+        "@comunica/context-entries": "^2.10.0",
+        "@comunica/core": "^2.10.0",
+        "@comunica/mediatortype-join-coefficients": "^2.10.0",
+        "@comunica/types": "^2.10.0"
+      }
+    },
+    "node_modules/@comunica/mediator-number": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/mediator-number/-/mediator-number-2.10.0.tgz",
+      "integrity": "sha512-0T8D1HGTu5Sd8iKb2dBjc6VRc/U4A15TAN6m561ra9pFlP+w31kby0ZYP6WWBHBobbUsX1LCvnbRQaAC4uWwVw==",
+      "dependencies": {
+        "@comunica/core": "^2.10.0"
+      }
+    },
+    "node_modules/@comunica/mediator-race": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/mediator-race/-/mediator-race-2.10.0.tgz",
+      "integrity": "sha512-JiEtOLMkPnbjSLabVpE4VqDbu2ZKKnkUdATGBeWX+o+MjPw6c0hhw01RG4WY2rQhDyNl++nLQe3EowQh8xW9TA==",
+      "dependencies": {
+        "@comunica/core": "^2.10.0"
+      }
+    },
+    "node_modules/@comunica/mediatortype-accuracy": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/mediatortype-accuracy/-/mediatortype-accuracy-2.10.0.tgz",
+      "integrity": "sha512-u9Noai4yGACaBRGOoRZ65XoQhazKNx5QaFOX5nJ/p84Qq4g50woC2rpsncuyrXhW1j/rIc2WvIUGUfy/g6CDiw==",
+      "dependencies": {
+        "@comunica/core": "^2.10.0"
+      }
+    },
+    "node_modules/@comunica/mediatortype-httprequests": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/mediatortype-httprequests/-/mediatortype-httprequests-2.10.0.tgz",
+      "integrity": "sha512-uPjs/NdngHZZWomjZor6W29UeOlxganupIOa3Z6H3qdUnsSpxeoS9URXy7BICAX+4PmgebperSn18BRA+PWiSw==",
+      "dependencies": {
+        "@comunica/core": "^2.10.0"
+      }
+    },
+    "node_modules/@comunica/mediatortype-join-coefficients": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/mediatortype-join-coefficients/-/mediatortype-join-coefficients-2.10.0.tgz",
+      "integrity": "sha512-EPipAV5PDNeEVXbsd+8NsqNKu5ztCAoEJ3azcFAmD9di9ppArNJWU/mxy5yUzcBgMUX4wRp6jCa5rIF5sRHG7g==",
+      "dependencies": {
+        "@comunica/core": "^2.10.0",
+        "@rdfjs/types": "*"
+      }
+    },
+    "node_modules/@comunica/mediatortype-time": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/mediatortype-time/-/mediatortype-time-2.10.0.tgz",
+      "integrity": "sha512-nBz1exxrja1Tj8KSlSevG4Hw2u09tTh6gtNfVjI76i/e7muu4RUWVhi9b8PcwBNAfuUqRl+5OgOSa2X4W+6QlA==",
+      "dependencies": {
+        "@comunica/core": "^2.10.0"
+      }
+    },
+    "node_modules/@comunica/metadata": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/metadata/-/metadata-2.10.0.tgz",
+      "integrity": "sha512-PF7TKhuDIO4GE9tzuAkTxarQV5cmwXZ64hp0qm8Ql/V+dVHu/3xLL9v/Q67ZX26GF9hOyr7cdpNI08M7DHc86g==",
+      "dependencies": {
+        "@comunica/types": "^2.10.0"
+      }
+    },
+    "node_modules/@comunica/query-sparql": {
+      "version": "2.10.2",
+      "resolved": "https://registry.npmjs.org/@comunica/query-sparql/-/query-sparql-2.10.2.tgz",
+      "integrity": "sha512-bgjQ8N5/vP3Iy71AgDKQc06mXmEBvh7dsenw2VPbvk11iXywec4XCq8TzX+GozL+Zxxl5XyYlBw+nRjvORTGHg==",
+      "dependencies": {
+        "@comunica/actor-context-preprocess-source-to-destination": "^2.10.0",
+        "@comunica/actor-dereference-fallback": "^2.10.0",
+        "@comunica/actor-dereference-http": "^2.10.2",
+        "@comunica/actor-dereference-rdf-parse": "^2.10.0",
+        "@comunica/actor-hash-bindings-sha1": "^2.10.0",
+        "@comunica/actor-http-fetch": "^2.10.2",
+        "@comunica/actor-http-proxy": "^2.10.2",
+        "@comunica/actor-http-wayback": "^2.10.2",
+        "@comunica/actor-init-query": "^2.10.2",
+        "@comunica/actor-optimize-query-operation-bgp-to-join": "^2.10.0",
+        "@comunica/actor-optimize-query-operation-join-bgp": "^2.10.0",
+        "@comunica/actor-optimize-query-operation-join-connected": "^2.10.0",
+        "@comunica/actor-query-operation-ask": "^2.10.1",
+        "@comunica/actor-query-operation-bgp-join": "^2.10.1",
+        "@comunica/actor-query-operation-construct": "^2.10.1",
+        "@comunica/actor-query-operation-describe-subject": "^2.10.1",
+        "@comunica/actor-query-operation-distinct-hash": "^2.10.1",
+        "@comunica/actor-query-operation-extend": "^2.10.1",
+        "@comunica/actor-query-operation-filter-sparqlee": "^2.10.1",
+        "@comunica/actor-query-operation-from-quad": "^2.10.1",
+        "@comunica/actor-query-operation-group": "^2.10.1",
+        "@comunica/actor-query-operation-join": "^2.10.1",
+        "@comunica/actor-query-operation-leftjoin": "^2.10.1",
+        "@comunica/actor-query-operation-minus": "^2.10.1",
+        "@comunica/actor-query-operation-nop": "^2.10.1",
+        "@comunica/actor-query-operation-orderby-sparqlee": "^2.10.1",
+        "@comunica/actor-query-operation-path-alt": "^2.10.1",
+        "@comunica/actor-query-operation-path-inv": "^2.10.1",
+        "@comunica/actor-query-operation-path-link": "^2.10.1",
+        "@comunica/actor-query-operation-path-nps": "^2.10.1",
+        "@comunica/actor-query-operation-path-one-or-more": "^2.10.1",
+        "@comunica/actor-query-operation-path-seq": "^2.10.1",
+        "@comunica/actor-query-operation-path-zero-or-more": "^2.10.1",
+        "@comunica/actor-query-operation-path-zero-or-one": "^2.10.1",
+        "@comunica/actor-query-operation-project": "^2.10.1",
+        "@comunica/actor-query-operation-quadpattern": "^2.10.1",
+        "@comunica/actor-query-operation-reduced-hash": "^2.10.1",
+        "@comunica/actor-query-operation-service": "^2.10.1",
+        "@comunica/actor-query-operation-slice": "^2.10.1",
+        "@comunica/actor-query-operation-sparql-endpoint": "^2.10.2",
+        "@comunica/actor-query-operation-union": "^2.10.1",
+        "@comunica/actor-query-operation-update-add-rewrite": "^2.10.1",
+        "@comunica/actor-query-operation-update-clear": "^2.10.2",
+        "@comunica/actor-query-operation-update-compositeupdate": "^2.10.1",
+        "@comunica/actor-query-operation-update-copy-rewrite": "^2.10.1",
+        "@comunica/actor-query-operation-update-create": "^2.10.2",
+        "@comunica/actor-query-operation-update-deleteinsert": "^2.10.2",
+        "@comunica/actor-query-operation-update-drop": "^2.10.2",
+        "@comunica/actor-query-operation-update-load": "^2.10.2",
+        "@comunica/actor-query-operation-update-move-rewrite": "^2.10.1",
+        "@comunica/actor-query-operation-values": "^2.10.1",
+        "@comunica/actor-query-parse-graphql": "^2.10.0",
+        "@comunica/actor-query-parse-sparql": "^2.10.0",
+        "@comunica/actor-query-result-serialize-json": "^2.10.0",
+        "@comunica/actor-query-result-serialize-rdf": "^2.10.0",
+        "@comunica/actor-query-result-serialize-simple": "^2.10.0",
+        "@comunica/actor-query-result-serialize-sparql-csv": "^2.10.0",
+        "@comunica/actor-query-result-serialize-sparql-json": "^2.10.2",
+        "@comunica/actor-query-result-serialize-sparql-tsv": "^2.10.0",
+        "@comunica/actor-query-result-serialize-sparql-xml": "^2.10.0",
+        "@comunica/actor-query-result-serialize-stats": "^2.10.2",
+        "@comunica/actor-query-result-serialize-table": "^2.10.0",
+        "@comunica/actor-query-result-serialize-tree": "^2.10.0",
+        "@comunica/actor-rdf-join-entries-sort-cardinality": "^2.10.0",
+        "@comunica/actor-rdf-join-inner-hash": "^2.10.1",
+        "@comunica/actor-rdf-join-inner-multi-bind": "^2.10.1",
+        "@comunica/actor-rdf-join-inner-multi-empty": "^2.10.1",
+        "@comunica/actor-rdf-join-inner-multi-smallest": "^2.10.1",
+        "@comunica/actor-rdf-join-inner-nestedloop": "^2.10.1",
+        "@comunica/actor-rdf-join-inner-none": "^2.10.1",
+        "@comunica/actor-rdf-join-inner-single": "^2.10.1",
+        "@comunica/actor-rdf-join-inner-symmetrichash": "^2.10.1",
+        "@comunica/actor-rdf-join-minus-hash": "^2.10.1",
+        "@comunica/actor-rdf-join-minus-hash-undef": "^2.10.1",
+        "@comunica/actor-rdf-join-optional-bind": "^2.10.1",
+        "@comunica/actor-rdf-join-optional-nestedloop": "^2.10.1",
+        "@comunica/actor-rdf-join-selectivity-variable-counting": "^2.10.0",
+        "@comunica/actor-rdf-metadata-accumulate-cancontainundefs": "^2.10.0",
+        "@comunica/actor-rdf-metadata-accumulate-cardinality": "^2.10.0",
+        "@comunica/actor-rdf-metadata-accumulate-pagesize": "^2.10.0",
+        "@comunica/actor-rdf-metadata-accumulate-requesttime": "^2.10.0",
+        "@comunica/actor-rdf-metadata-all": "^2.10.0",
+        "@comunica/actor-rdf-metadata-extract-allow-http-methods": "^2.10.0",
+        "@comunica/actor-rdf-metadata-extract-hydra-controls": "^2.10.0",
+        "@comunica/actor-rdf-metadata-extract-hydra-count": "^2.10.0",
+        "@comunica/actor-rdf-metadata-extract-hydra-pagesize": "^2.10.0",
+        "@comunica/actor-rdf-metadata-extract-patch-sparql-update": "^2.10.0",
+        "@comunica/actor-rdf-metadata-extract-put-accepted": "^2.10.0",
+        "@comunica/actor-rdf-metadata-extract-request-time": "^2.10.0",
+        "@comunica/actor-rdf-metadata-extract-sparql-service": "^2.10.0",
+        "@comunica/actor-rdf-metadata-primary-topic": "^2.10.0",
+        "@comunica/actor-rdf-parse-html": "^2.10.0",
+        "@comunica/actor-rdf-parse-html-microdata": "^2.10.0",
+        "@comunica/actor-rdf-parse-html-rdfa": "^2.10.0",
+        "@comunica/actor-rdf-parse-html-script": "^2.10.0",
+        "@comunica/actor-rdf-parse-jsonld": "^2.10.2",
+        "@comunica/actor-rdf-parse-n3": "^2.10.0",
+        "@comunica/actor-rdf-parse-rdfxml": "^2.10.0",
+        "@comunica/actor-rdf-parse-shaclc": "^2.10.0",
+        "@comunica/actor-rdf-parse-xml-rdfa": "^2.10.0",
+        "@comunica/actor-rdf-resolve-hypermedia-links-next": "^2.10.0",
+        "@comunica/actor-rdf-resolve-hypermedia-links-queue-fifo": "^2.10.0",
+        "@comunica/actor-rdf-resolve-hypermedia-none": "^2.10.0",
+        "@comunica/actor-rdf-resolve-hypermedia-qpf": "^2.10.0",
+        "@comunica/actor-rdf-resolve-hypermedia-sparql": "^2.10.2",
+        "@comunica/actor-rdf-resolve-quad-pattern-federated": "^2.10.1",
+        "@comunica/actor-rdf-resolve-quad-pattern-hypermedia": "^2.10.1",
+        "@comunica/actor-rdf-resolve-quad-pattern-rdfjs-source": "^2.10.0",
+        "@comunica/actor-rdf-resolve-quad-pattern-string-source": "^2.10.0",
+        "@comunica/actor-rdf-serialize-jsonld": "^2.10.0",
+        "@comunica/actor-rdf-serialize-n3": "^2.10.0",
+        "@comunica/actor-rdf-serialize-shaclc": "^2.10.0",
+        "@comunica/actor-rdf-update-hypermedia-patch-sparql-update": "^2.10.2",
+        "@comunica/actor-rdf-update-hypermedia-put-ldp": "^2.10.2",
+        "@comunica/actor-rdf-update-hypermedia-sparql": "^2.10.2",
+        "@comunica/actor-rdf-update-quads-hypermedia": "^2.10.2",
+        "@comunica/actor-rdf-update-quads-rdfjs-store": "^2.10.2",
+        "@comunica/bus-http-invalidate": "^2.10.0",
+        "@comunica/bus-query-operation": "^2.10.1",
+        "@comunica/config-query-sparql": "^2.7.0",
+        "@comunica/core": "^2.10.0",
+        "@comunica/logger-void": "^2.10.0",
+        "@comunica/mediator-all": "^2.10.0",
+        "@comunica/mediator-combine-pipeline": "^2.10.0",
+        "@comunica/mediator-combine-union": "^2.10.0",
+        "@comunica/mediator-join-coefficients-fixed": "^2.10.1",
+        "@comunica/mediator-number": "^2.10.0",
+        "@comunica/mediator-race": "^2.10.0",
+        "@comunica/runner": "^2.10.0",
+        "@comunica/runner-cli": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "process": "^0.11.10"
+      },
+      "bin": {
+        "comunica-dynamic-sparql": "bin/query-dynamic.js",
+        "comunica-sparql": "bin/query.js",
+        "comunica-sparql-http": "bin/http.js"
+      }
+    },
+    "node_modules/@comunica/runner": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/runner/-/runner-2.10.0.tgz",
+      "integrity": "sha512-v/oEKT+IwjO6Y74bCCzlR+ZMI6oykpfz7GQrQbl1oTWQsvBbTdf0omPkoYnk1esEAsFnsJD+NGwAiRiFKeBo0A==",
+      "dependencies": {
+        "@comunica/bus-init": "^2.10.0",
+        "@comunica/core": "^2.10.0",
+        "componentsjs": "^5.3.2",
+        "process": "^0.11.10"
+      },
+      "bin": {
+        "comunica-compile-config": "bin/compile-config"
+      }
+    },
+    "node_modules/@comunica/runner-cli": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/runner-cli/-/runner-cli-2.10.0.tgz",
+      "integrity": "sha512-16QI0rWFHURCy5waVFcZ/fhKI/hyzNx5YyCGPaEaUX8MKyamvCCXHSWvPLLbjJbsjGZ9wXrC9dwwhRmbfmidpw==",
+      "dependencies": {
+        "@comunica/core": "^2.10.0",
+        "@comunica/runner": "^2.10.0",
+        "@comunica/types": "^2.10.0",
+        "process": "^0.11.10"
+      },
+      "bin": {
+        "comunica-run": "bin/run.js"
+      }
+    },
+    "node_modules/@comunica/types": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@comunica/types/-/types-2.10.0.tgz",
+      "integrity": "sha512-1UjPGbZcYrapBjMGUZedrIGcn9rOLpEOlJo1ZkWddFUGTwndVg9d4BZnQw+UnQzXMcLJcdKt94Zns8iEmBqARw==",
+      "dependencies": {
+        "@rdfjs/types": "*",
+        "@types/yargs": "^17.0.24",
+        "asynciterator": "^3.8.1",
+        "sparqlalgebrajs": "^4.2.0"
+      }
+    },
+    "node_modules/@dabh/diagnostics": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.3.tgz",
+      "integrity": "sha512-hrlQOIi7hAfzsMqlGSFyVucrx38O+j6wiGOf//H2ecvIEqYN4ADBSS2iLMh5UFyDunCNniUIPk/q3riFv45xRA==",
+      "dependencies": {
+        "colorspace": "1.1.x",
+        "enabled": "2.0.x",
+        "kuler": "^2.0.0"
+      }
+    },
+    "node_modules/@digitalbazaar/http-client": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@digitalbazaar/http-client/-/http-client-3.4.1.tgz",
+      "integrity": "sha512-Ahk1N+s7urkgj7WvvUND5f8GiWEPfUw0D41hdElaqLgu8wZScI8gdI0q+qWw5N1d35x7GCRH2uk9mi+Uzo9M3g==",
+      "dependencies": {
+        "ky": "^0.33.3",
+        "ky-universal": "^0.11.0",
+        "undici": "^5.21.2"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
+    "node_modules/@fastify/busboy": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.0.tgz",
+      "integrity": "sha512-+KpH+QxZU7O4675t3mnkQKcZZg56u+K/Ct2K+N2AZYNVK8kyeo/bI18tI8aPm3tvNNRyTWfj6s5tnGNlcbQRsA==",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@jeswr/prefixcc": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@jeswr/prefixcc/-/prefixcc-1.2.1.tgz",
+      "integrity": "sha512-kBBXbqsaeh3Irp416h/RbelqJgIOp6X/OJJlYmLyr/9qlBYKTKSCuEv5/xjZ0Yf8Yec+QFRYBaOQ2JkMBSH7KA==",
+      "dependencies": {
+        "cross-fetch": "^3.1.5"
+      },
+      "optionalDependencies": {
+        "fsevents": "^2.3.2"
+      }
+    },
+    "node_modules/@jeswr/prefixcc/node_modules/cross-fetch": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.8.tgz",
+      "integrity": "sha512-cvA+JwZoU0Xq+h6WkMvAUqPEYy92Obet6UdKLfW60qn99ftItKjB5T+BkyWOFWe2pUyfQ+IJHmpOTznqk1M6Kg==",
+      "dependencies": {
+        "node-fetch": "^2.6.12"
+      }
+    },
+    "node_modules/@rdfjs/types": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@rdfjs/types/-/types-1.1.0.tgz",
+      "integrity": "sha512-5zm8bN2/CC634dTcn/0AhTRLaQRjXDZs3QfcAsQKNturHT7XVWcKy/8p3P5gXl+YkZTAmy7T5M/LyiT/jbkENw==",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@rubensworks/saxes": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@rubensworks/saxes/-/saxes-6.0.1.tgz",
+      "integrity": "sha512-UW4OTIsOtJ5KSXo2Tchi4lhZqu+tlHrOAs4nNti7CrtB53kAZl3/hyrTi6HkMihxdbDM6m2Zc3swc/ZewEe1xw==",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.12"
+      }
+    },
+    "node_modules/@smessie/readable-web-to-node-stream": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@smessie/readable-web-to-node-stream/-/readable-web-to-node-stream-3.0.3.tgz",
+      "integrity": "sha512-8FFE7psRtRWQT31/duqbmgnSf2++QLR2YH9kj5iwsHhnoqSvHdOY3SAN5e7dhc+60p2cNk7rv3HYOiXOapTEXQ==",
+      "dependencies": {
+        "process": "^0.11.10",
+        "readable-stream": "^4.5.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/@treecg/actor-rdf-frame-with-json-ld-js": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@treecg/actor-rdf-frame-with-json-ld-js/-/actor-rdf-frame-with-json-ld-js-4.0.0.tgz",
+      "integrity": "sha512-LMgOKn60FQCOxUMzVkpUR/RwaVdZHOMbwMXyam4DS2egfluydWCfJW38p9Bo19BBvfja1WlnmnbO5azOWFLTzg==",
+      "dependencies": {
+        "@types/jsonld": "^1.5.8",
+        "jsonld": "^8.1.1"
+      }
+    },
+    "node_modules/@treecg/actor-rdf-metadata-extract-tree": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@treecg/actor-rdf-metadata-extract-tree/-/actor-rdf-metadata-extract-tree-2.0.0.tgz",
+      "integrity": "sha512-15ysrCQ2vx+UN1yCtx9g4T6nj7QiHjPDd/r/KUwcrdTzTktz/z3bOSIojxugMCW6PrxxUqTEVx5I506TSamq8A==",
+      "dependencies": {
+        "@comunica/bus-rdf-metadata-extract": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@treecg/tree-metadata-extraction": "^1.2.1",
+        "typescript": "^4.7.4"
+      }
+    },
+    "node_modules/@treecg/bus-rdf-filter-object": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@treecg/bus-rdf-filter-object/-/bus-rdf-filter-object-4.0.0.tgz",
+      "integrity": "sha512-CjMKHKoR/fL4xZTN0c6qylYR1KurICfSkt+c+EjS1JUFBO+HjjigNcYc+FjP2TkiXM72Q0ojfarcXmnnzxynFg==",
+      "dependencies": {
+        "@comunica/core": "^2.6.8"
+      }
+    },
+    "node_modules/@treecg/bus-rdf-frame": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@treecg/bus-rdf-frame/-/bus-rdf-frame-4.0.0.tgz",
+      "integrity": "sha512-Wv74MP9ztV+5b0hIrpUKgm8UkL3RB2TR8S49V/q1s3e3GsVEs6Bvo4DQSLuZpfpY344jECMhI5GcpZETJIP/ww==",
+      "dependencies": {
+        "@comunica/core": "^2.6.8"
+      }
+    },
+    "node_modules/@treecg/tree-metadata-extraction": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@treecg/tree-metadata-extraction/-/tree-metadata-extraction-1.2.1.tgz",
+      "integrity": "sha512-Fr4+xBpjOrYWjlU7QbJmmVU5sobOO6Gcpf05HLRh7nVGOkedPcRujxs4TBWDSl8iVpzosviwvW8OUQw7hDW+vw==",
+      "dependencies": {
+        "n3": "^1.6.3"
+      }
+    },
+    "node_modules/@treecg/types": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/@treecg/types/-/types-0.4.5.tgz",
+      "integrity": "sha512-vPEVVlRDPQz8KwQmC6SKW5cTgggrBmEapw1Plg7beVX6pmfM1bll7lMnHGNLJDmoDyfAkR6LV4nB/VLGpjGBPA==",
+      "dependencies": {
+        "@rdfjs/types": "*",
+        "loglevel": "^1.8.1",
+        "loglevel-plugin-prefix": "^0.8.4",
+        "rdf-data-factory": "^1.1.0"
+      }
+    },
+    "node_modules/@types/content-type": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/@types/content-type/-/content-type-1.1.8.tgz",
+      "integrity": "sha512-1tBhmVUeso3+ahfyaKluXe38p+94lovUZdoVfQ3OnJo9uJC42JT7CBoN3k9HYhAae+GwiBYmHu+N9FZhOG+2Pg==",
+      "dev": true
+    },
+    "node_modules/@types/http-cache-semantics": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz",
+      "integrity": "sha512-1m0bIFVc7eJWyve9S0RnuRgcQqF/Xd5QsUZAZeQFr1Q3/p9JWoQQEqmVy+DPTNpGXwhgIetAoYF8JSc33q29QA==",
+      "dev": true
+    },
+    "node_modules/@types/http-link-header": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/http-link-header/-/http-link-header-1.0.5.tgz",
+      "integrity": "sha512-AxhIKR8UbyoqCTNp9rRepkktHuUOw3DjfOfDCaO9kwI8AYzjhxyrvZq4+mRw/2daD3hYDknrtSeV6SsPwmc71w==",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/jsonld": {
+      "version": "1.5.13",
+      "resolved": "https://registry.npmjs.org/@types/jsonld/-/jsonld-1.5.13.tgz",
+      "integrity": "sha512-n7fUU6W4kSYK8VQlf/LsE9kddBHPKhODoVOjsZswmve+2qLwBy6naWxs/EiuSZN9NU0N06Ra01FR+j87C62T0A=="
+    },
+    "node_modules/@types/minimist": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-hov8bUuiLiyFPGyFPE1lwWhmzYbirOXQNNo40+y3zow8aFVTeyn3VWL0VFFfdNddA8S4Vf0Tc062rzyNr7Paag=="
+    },
+    "node_modules/@types/n3": {
+      "version": "1.16.4",
+      "resolved": "https://registry.npmjs.org/@types/n3/-/n3-1.16.4.tgz",
+      "integrity": "sha512-6PmHRYCCdjbbBV2UVC/HjtL6/5Orx9ku2CQjuojucuHvNvPmnm6+02B18YGhHfvU25qmX2jPXyYPHsMNkn+w2w==",
+      "dependencies": {
+        "@rdfjs/types": "^1.1.0",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.11.19",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.19.tgz",
+      "integrity": "sha512-7xMnVEcZFu0DikYjWOlRq7NTPETrm7teqUT2WkQjrTIkEgUyyGdWsj/Zg8bEJt5TNklzbPD1X3fqfsHw3SpapQ==",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@types/readable-stream": {
+      "version": "2.3.15",
+      "resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-2.3.15.tgz",
+      "integrity": "sha512-oM5JSKQCcICF1wvGgmecmHldZ48OZamtMxcGGVICOJA8o8cahXC1zEVAif8iwoc5j8etxFaRFnf095+CDsuoFQ==",
+      "dependencies": {
+        "@types/node": "*",
+        "safe-buffer": "~5.1.1"
+      }
+    },
+    "node_modules/@types/semver": {
+      "version": "7.5.7",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.7.tgz",
+      "integrity": "sha512-/wdoPq1QqkSj9/QOeKkFquEuPzQbHTWAMPH/PaUMB+JuR31lXhlWXRZ52IpfDYVlDOUBvX09uBrPwxGT1hjNBg=="
+    },
+    "node_modules/@types/spark-md5": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/spark-md5/-/spark-md5-3.0.4.tgz",
+      "integrity": "sha512-qtOaDz+IXiNndPgYb6t1YoutnGvFRtWSNzpVjkAPCfB2UzTyybuD4Tjgs7VgRawum3JnJNRwNQd4N//SvrHg1Q=="
+    },
+    "node_modules/@types/sparqljs": {
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/@types/sparqljs/-/sparqljs-3.1.10.tgz",
+      "integrity": "sha512-rqMpUhl/d8B+vaACa6ZVdwPQ1JXw+KxiCc0cndgn/V6moRG3WjUAgoBnhSwfKtXD98wgMThDsc6R1+yRUuMsAg==",
+      "dependencies": {
+        "@rdfjs/types": ">=1.0.0"
+      }
+    },
+    "node_modules/@types/streamify-string": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@types/streamify-string/-/streamify-string-1.0.4.tgz",
+      "integrity": "sha512-lFME26GYMkG5C9ydkqaIZ9Jnylk0yhEO2MYpKCf1CifCq32alaXfhi3HcquydYnOGM/VTb9S++JRFZ44rBvRZQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/triple-beam": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.5.tgz",
+      "integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw=="
+    },
+    "node_modules/@types/uritemplate": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@types/uritemplate/-/uritemplate-0.3.6.tgz",
+      "integrity": "sha512-31BMGZ8GgLxgXxLnqg4KbbyYJjU1flhTTD2+PVQStVUPXSk0IIpK0zt+tH3eLT7ZRwLnzQw6JhYx69qza3U0wg=="
+    },
+    "node_modules/@types/uuid": {
+      "version": "9.0.8",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.8.tgz",
+      "integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA=="
+    },
+    "node_modules/@types/yargs": {
+      "version": "17.0.32",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.32.tgz",
+      "integrity": "sha512-xQ67Yc/laOG5uMfX/093MRlGGCIBzZMarVa+gfNKJxWAIgykYpVGkBdbqEzGDDfCrVUj6Hiff4mTZ5BA6TmAog==",
+      "dependencies": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "node_modules/@types/yargs-parser": {
+      "version": "21.0.3",
+      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
+      "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ=="
+    },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/ansi-styles/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "node_modules/arrayify-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/arrayify-stream/-/arrayify-stream-2.0.1.tgz",
+      "integrity": "sha512-z8fB6PtmnewQpFB53piS2d1KlUi3BPMICH2h7leCOUXpQcwvZ4GbHHSpdKoUrgLMR6b4Qan/uDe1St3Ao3yIHg=="
+    },
+    "node_modules/async": {
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.5.tgz",
+      "integrity": "sha512-baNZyqaaLhyLVKm/DlvdW051MSgO6b8eVfIezl9E5PqWxFgzLm/wQntEW4zOytVburDEr0JlALEpdOFwvErLsg=="
+    },
+    "node_modules/asynciterator": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/asynciterator/-/asynciterator-3.8.1.tgz",
+      "integrity": "sha512-SmdG0FUY3pYGOZZGdYq8Qb/DCRDXBFZUk08V1/4lbBXdAQvcC3Kxzz9FUDPBTik7VAVltt4cZirAPtJv3gOpEw=="
+    },
+    "node_modules/asyncjoin": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/asyncjoin/-/asyncjoin-1.1.2.tgz",
+      "integrity": "sha512-zi6B+C3GgEu8qrmFn3gDd58cbGNaNFW3s8DJmCxUOjQwqWZcQO6dEoZBWl56+QGQyX0da0FRX1fsAyYB9LmwJA==",
+      "dependencies": {
+        "asynciterator": "^3.6.0"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.2.tgz",
+      "integrity": "sha512-2/mKyZH9K85bzOEfhXDBFZTGd1CTs+5IHpeFQo9luiBG7hghdC851Pj2WAhb6E3R6b9tZj/XKhbg4fum+Kepug==",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/canonicalize": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/canonicalize/-/canonicalize-2.0.0.tgz",
+      "integrity": "sha512-ulDEYPv7asdKvqahuAY35c1selLdzDwHqugK92hfkzvlDCwXRRelDkR+Er33md/PtnpqHemgkuDPanZ4fiYZ8w=="
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/color": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/color/-/color-3.2.1.tgz",
+      "integrity": "sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==",
+      "dependencies": {
+        "color-convert": "^1.9.3",
+        "color-string": "^1.6.0"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
+    },
+    "node_modules/color-string": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+      "dependencies": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
+    },
+    "node_modules/colorspace": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.1.4.tgz",
+      "integrity": "sha512-BgvKJiuVu1igBUF2kEjRCZXol6wiiGbY5ipL/oVPwm0BL9sIpMIzM8IK7vwuxIIzOXMV3Ey5w+vxhm0rR/TN8w==",
+      "dependencies": {
+        "color": "^3.1.3",
+        "text-hex": "1.0.x"
+      }
+    },
+    "node_modules/componentsjs": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/componentsjs/-/componentsjs-5.5.1.tgz",
+      "integrity": "sha512-hmqq+ZUa98t9CoeWPGwE14I18aXQFAt66HRd8DaZCNggcSr82vhlyrjeXX0JAUMgr2MyQzwKstkv4INRAREguA==",
+      "dependencies": {
+        "@rdfjs/types": "*",
+        "@types/minimist": "^1.2.0",
+        "@types/node": "^18.0.0",
+        "@types/semver": "^7.3.4",
+        "jsonld-context-parser": "^2.1.1",
+        "minimist": "^1.2.0",
+        "rdf-data-factory": "^1.1.0",
+        "rdf-object": "^1.14.0",
+        "rdf-parse": "^2.0.0",
+        "rdf-quad": "^1.5.0",
+        "rdf-string": "^1.6.0",
+        "rdf-terms": "^1.7.0",
+        "semver": "^7.3.2",
+        "winston": "^3.3.3"
+      },
+      "bin": {
+        "componentsjs-compile-config": "bin/compile-config.js"
+      }
+    },
+    "node_modules/componentsjs/node_modules/@types/node": {
+      "version": "18.19.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.17.tgz",
+      "integrity": "sha512-SzyGKgwPzuWp2SHhlpXKzCX0pIOfcI4V2eF37nNBJOhwlegQ83omtVQ1XxZpDE06V/d6AQvfQdPfnw0tRC//Ng==",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cross-fetch": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.0.0.tgz",
+      "integrity": "sha512-e4a5N8lVvuLgAWgnCrLr2PP0YyDOTHa9H/Rj54dirp61qXnNq46m82bRhNqIA5VccJtWBvPTFRV3TtvHUKPB1g==",
+      "dependencies": {
+        "node-fetch": "^2.6.12"
+      }
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ]
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.1.0.tgz",
+      "integrity": "sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+    },
+    "node_modules/enabled": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
+      "integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ=="
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.2.tgz",
+      "integrity": "sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
+    "node_modules/exponential-backoff": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.1.tgz",
+      "integrity": "sha512-dX7e/LHVJ6W3DE1MHWi9S1EYzDESENfLrYohG2G++ovZrYOkm4Knwa0mc1cn84xJOR4KEU0WSchhLbd0UklbHw=="
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+    },
+    "node_modules/fecha": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
+      "integrity": "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw=="
+    },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
+    "node_modules/fetch-sparql-endpoint": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/fetch-sparql-endpoint/-/fetch-sparql-endpoint-4.1.1.tgz",
+      "integrity": "sha512-q0TLXPoAM/rA3OaHH4LvfJzaN8vVmaEVNNFtH3xsz9L40YIiAWSdbg2c/Ze/JL75kf8Iktbh1tItHZoottCh2Q==",
+      "dependencies": {
+        "@rdfjs/types": "*",
+        "@smessie/readable-web-to-node-stream": "^3.0.3",
+        "@types/readable-stream": "^2.3.11",
+        "@types/sparqljs": "^3.1.3",
+        "abort-controller": "^3.0.0",
+        "cross-fetch": "^3.0.6",
+        "is-stream": "^2.0.0",
+        "minimist": "^1.2.0",
+        "n3": "^1.6.3",
+        "rdf-string": "^1.6.0",
+        "sparqljs": "^3.1.2",
+        "sparqljson-parse": "^2.2.0",
+        "sparqlxml-parse": "^2.1.1",
+        "stream-to-string": "^1.1.0"
+      },
+      "bin": {
+        "fetch-sparql-endpoint": "bin/fetch-sparql-endpoint.js"
+      }
+    },
+    "node_modules/fetch-sparql-endpoint/node_modules/cross-fetch": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.8.tgz",
+      "integrity": "sha512-cvA+JwZoU0Xq+h6WkMvAUqPEYy92Obet6UdKLfW60qn99ftItKjB5T+BkyWOFWe2pUyfQ+IJHmpOTznqk1M6Kg==",
+      "dependencies": {
+        "node-fetch": "^2.6.12"
+      }
+    },
+    "node_modules/fn.name": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
+      "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/graphql": {
+      "version": "15.8.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.8.0.tgz",
+      "integrity": "sha512-5gghUc24tP9HRznNpV2+FIoq3xKkj5dTQqf4v0CpdPbFVwFkWoxOM+o+2OC9ZSvjEMTjfmG9QT+gcvggTwW1zw==",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
+    "node_modules/graphql-to-sparql": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/graphql-to-sparql/-/graphql-to-sparql-3.0.1.tgz",
+      "integrity": "sha512-A+RwB99o66CUj+XuqtP/u3P7fGS/qF6P+/jhNl1BE/JZ2SCnkrODvV0LADuJeCDmPh45fDhq+GTDVoN1ZQHYFw==",
+      "dependencies": {
+        "@rdfjs/types": "*",
+        "graphql": "^15.5.2",
+        "jsonld-context-parser": "^2.0.2",
+        "minimist": "^1.2.0",
+        "rdf-data-factory": "^1.1.0",
+        "sparqlalgebrajs": "^4.0.0"
+      },
+      "bin": {
+        "graphql-to-sparql": "bin/graphql-to-sparql.js"
+      }
+    },
+    "node_modules/hash.js": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+      "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "minimalistic-assert": "^1.0.1"
+      }
+    },
+    "node_modules/htmlparser2": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-9.1.0.tgz",
+      "integrity": "sha512-5zfg6mHUoaer/97TxnGpxmbR7zJtPwIYFMZ/H5ucTlPZhKvtum05yiPK3Mgai3a0DyVxv7qYqoweaEd2nrYQzQ==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.1.0",
+        "entities": "^4.5.0"
+      }
+    },
+    "node_modules/http-cache-semantics": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
+      "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ=="
+    },
+    "node_modules/http-link-header": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/http-link-header/-/http-link-header-1.1.1.tgz",
+      "integrity": "sha512-mW3N/rTYpCn99s1do0zx6nzFZSwLH9HGfUM4ZqLWJ16ylmYaC2v5eYGqrNTQlByx8AzUgGI+V/32gXPugs1+Sw==",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/immutable": {
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.5.tgz",
+      "integrity": "sha512-8eabxkth9gZatlwl5TBuJnCsoTADlL6ftEr7A4qgdaTsPyreilDSnUk57SO+jfKcNtxPa22U5KK6DSeAYhpBJw=="
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+      "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/js-priority-queue": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/js-priority-queue/-/js-priority-queue-0.1.5.tgz",
+      "integrity": "sha512-2dPmJT4GbXUpob7AZDR1wFMKz3Biy6oW69mwt5PTtdeoOgDin1i0p5gUV9k0LFeUxDpwkfr+JGMZDpcprjiY5w=="
+    },
+    "node_modules/jsonld": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/jsonld/-/jsonld-8.3.2.tgz",
+      "integrity": "sha512-MwBbq95szLwt8eVQ1Bcfwmgju/Y5P2GdtlHE2ncyfuYjIdEhluUVyj1eudacf1mOkWIoS9GpDBTECqhmq7EOaA==",
+      "dependencies": {
+        "@digitalbazaar/http-client": "^3.4.1",
+        "canonicalize": "^1.0.1",
+        "lru-cache": "^6.0.0",
+        "rdf-canonize": "^3.4.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/jsonld-context-parser": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/jsonld-context-parser/-/jsonld-context-parser-2.4.0.tgz",
+      "integrity": "sha512-ZYOfvh525SdPd9ReYY58dxB3E2RUEU4DJ6ZibO8AitcowPeBH4L5rCAitE2om5G1P+HMEgYEYEr4EZKbVN4tpA==",
+      "dependencies": {
+        "@types/http-link-header": "^1.0.1",
+        "@types/node": "^18.0.0",
+        "cross-fetch": "^3.0.6",
+        "http-link-header": "^1.0.2",
+        "relative-to-absolute-iri": "^1.0.5"
+      },
+      "bin": {
+        "jsonld-context-parse": "bin/jsonld-context-parse.js"
+      }
+    },
+    "node_modules/jsonld-context-parser/node_modules/@types/node": {
+      "version": "18.19.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.17.tgz",
+      "integrity": "sha512-SzyGKgwPzuWp2SHhlpXKzCX0pIOfcI4V2eF37nNBJOhwlegQ83omtVQ1XxZpDE06V/d6AQvfQdPfnw0tRC//Ng==",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/jsonld-context-parser/node_modules/cross-fetch": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.8.tgz",
+      "integrity": "sha512-cvA+JwZoU0Xq+h6WkMvAUqPEYy92Obet6UdKLfW60qn99ftItKjB5T+BkyWOFWe2pUyfQ+IJHmpOTznqk1M6Kg==",
+      "dependencies": {
+        "node-fetch": "^2.6.12"
+      }
+    },
+    "node_modules/jsonld-streaming-parser": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/jsonld-streaming-parser/-/jsonld-streaming-parser-3.3.0.tgz",
+      "integrity": "sha512-6aWiAsWGZioTB/vNQ3KenREz9ddEOliZoEETi+jLrlL7+vkgMeHjnxyFlGe4UOCU7SVUNPhz/lgLGZjnxgVYtA==",
+      "dependencies": {
+        "@bergos/jsonparse": "^1.4.0",
+        "@rdfjs/types": "*",
+        "@types/http-link-header": "^1.0.1",
+        "@types/readable-stream": "^2.3.13",
+        "buffer": "^6.0.3",
+        "canonicalize": "^1.0.1",
+        "http-link-header": "^1.0.2",
+        "jsonld-context-parser": "^2.4.0",
+        "rdf-data-factory": "^1.1.0",
+        "readable-stream": "^4.0.0"
+      }
+    },
+    "node_modules/jsonld-streaming-parser/node_modules/canonicalize": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/canonicalize/-/canonicalize-1.0.8.tgz",
+      "integrity": "sha512-0CNTVCLZggSh7bc5VkX5WWPWO+cyZbNd07IHIsSXLia/eAq+r836hgk+8BKoEh7949Mda87VUOitx5OddVj64A=="
+    },
+    "node_modules/jsonld-streaming-serializer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/jsonld-streaming-serializer/-/jsonld-streaming-serializer-2.1.0.tgz",
+      "integrity": "sha512-COHdLoeMTnrqHMoFhN3PoAwqnrKrpPC7/ACb0WbELYvt+HSOIFN3v4IJP7fOtLNQ4GeaeYkvbeWJ7Jo4EjxMDw==",
+      "dependencies": {
+        "@rdfjs/types": "*",
+        "@types/readable-stream": "^2.3.13",
+        "buffer": "^6.0.3",
+        "jsonld-context-parser": "^2.0.0",
+        "readable-stream": "^4.0.0"
+      }
+    },
+    "node_modules/jsonld/node_modules/canonicalize": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/canonicalize/-/canonicalize-1.0.8.tgz",
+      "integrity": "sha512-0CNTVCLZggSh7bc5VkX5WWPWO+cyZbNd07IHIsSXLia/eAq+r836hgk+8BKoEh7949Mda87VUOitx5OddVj64A=="
+    },
+    "node_modules/jsonld/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/kuler": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
+      "integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A=="
+    },
+    "node_modules/ky": {
+      "version": "0.33.3",
+      "resolved": "https://registry.npmjs.org/ky/-/ky-0.33.3.tgz",
+      "integrity": "sha512-CasD9OCEQSFIam2U8efFK81Yeg8vNMTBUqtMOHlrcWQHqUX3HeCl9Dr31u4toV7emlH8Mymk5+9p0lL6mKb/Xw==",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/ky?sponsor=1"
+      }
+    },
+    "node_modules/ky-universal": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/ky-universal/-/ky-universal-0.11.0.tgz",
+      "integrity": "sha512-65KyweaWvk+uKKkCrfAf+xqN2/epw1IJDtlyCPxYffFCMR8u1sp2U65NtWpnozYfZxQ6IUzIlvUcw+hQ82U2Xw==",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "node-fetch": "^3.2.10"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/ky-universal?sponsor=1"
+      },
+      "peerDependencies": {
+        "ky": ">=0.31.4",
+        "web-streams-polyfill": ">=3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "web-streams-polyfill": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ky-universal/node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/logform": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/logform/-/logform-2.6.0.tgz",
+      "integrity": "sha512-1ulHeNPp6k/LD8H91o7VYFBng5i1BDE7HoKxVbZiGFidS1Rj65qcywLxX+pVfAPoQJEjRdvKcusKwOupHCVOVQ==",
+      "dependencies": {
+        "@colors/colors": "1.6.0",
+        "@types/triple-beam": "^1.3.2",
+        "fecha": "^4.2.0",
+        "ms": "^2.1.1",
+        "safe-stable-stringify": "^2.3.1",
+        "triple-beam": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/loglevel": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.9.1.tgz",
+      "integrity": "sha512-hP3I3kCrDIMuRwAwHltphhDM1r8i55H33GgqjXbrisuJhF4kRhW1dNuxsRklp4bXl8DSdLaNLuiL4A/LWRfxvg==",
+      "engines": {
+        "node": ">= 0.6.0"
+      },
+      "funding": {
+        "type": "tidelift",
+        "url": "https://tidelift.com/funding/github/npm/loglevel"
+      }
+    },
+    "node_modules/loglevel-plugin-prefix": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/loglevel-plugin-prefix/-/loglevel-plugin-prefix-0.8.4.tgz",
+      "integrity": "sha512-WpG9CcFAOjz/FtNht+QJeGpvVl/cdR6P0z6OcXSkr8wFJOsV2GRj2j10JLfjuA4aYkcKCNIEqRGCyTife9R8/g=="
+    },
+    "node_modules/lru-cache": {
+      "version": "8.0.5",
+      "license": "ISC",
+      "engines": {
+        "node": ">=16.14"
+      }
+    },
+    "node_modules/microdata-rdf-streaming-parser": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/microdata-rdf-streaming-parser/-/microdata-rdf-streaming-parser-2.0.1.tgz",
+      "integrity": "sha512-oEEYP3OwPGOtoE4eIyJvX1eJXI7VkGR4gKYqpEufaRXc2ele/Tkid/KMU3Los13wGrOq6woSxLEGOYSHzpRvwA==",
+      "dependencies": {
+        "@rdfjs/types": "*",
+        "htmlparser2": "^8.0.0",
+        "rdf-data-factory": "^1.1.0",
+        "readable-stream": "^4.1.0",
+        "relative-to-absolute-iri": "^1.0.2"
+      }
+    },
+    "node_modules/microdata-rdf-streaming-parser/node_modules/htmlparser2": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
+      "integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1",
+        "entities": "^4.4.0"
+      }
+    },
+    "node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/moment": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
+    "node_modules/n3": {
+      "version": "1.17.2",
+      "resolved": "https://registry.npmjs.org/n3/-/n3-1.17.2.tgz",
+      "integrity": "sha512-BxSM52wYFqXrbQQT5WUEzKUn6qpYV+2L4XZLfn3Gblz2kwZ09S+QxC33WNdVEQy2djenFL8SNkrjejEKlvI6+Q==",
+      "dependencies": {
+        "queue-microtask": "^1.1.2",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12.0"
+      }
+    },
+    "node_modules/negotiate": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/negotiate/-/negotiate-1.0.1.tgz",
+      "integrity": "sha512-KBCIM4dAIT9j/pSXLHHQbZG74NmKNXTtxU2zHN0HG6uzzuFE01m1UdGoUmVHmACiBuCAOL7KwfqSW1oUQBj/vg=="
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.1.tgz",
+      "integrity": "sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/one-time": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
+      "integrity": "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==",
+      "dependencies": {
+        "fn.name": "1.x.x"
+      }
+    },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/promise-polyfill": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-1.1.6.tgz",
+      "integrity": "sha512-7rrONfyLkDEc7OJ5QBkqa4KI4EBhCd340xRuIUPGCfu13znS+vx+VDdrT9ODAJHlXm7w4lbxN3DRjyv58EuzDg=="
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/rdf-canonize": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/rdf-canonize/-/rdf-canonize-3.4.0.tgz",
+      "integrity": "sha512-fUeWjrkOO0t1rg7B2fdyDTvngj+9RlUyL92vOdiB7c0FPguWVsniIMjEtHH+meLBO9rzkUlUzBVXgWrjI8P9LA==",
+      "dependencies": {
+        "setimmediate": "^1.0.5"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/rdf-data-factory": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-1.1.2.tgz",
+      "integrity": "sha512-TfQD63Lokabd09ES1jAtKK8AA6rkr9rwyUBGo6olOt1CE0Um36CUQIqytyf0am2ouBPR0l7SaHxCiMcPGHkt1A==",
+      "dependencies": {
+        "@rdfjs/types": "*"
+      }
+    },
+    "node_modules/rdf-dereference": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/rdf-dereference/-/rdf-dereference-2.2.0.tgz",
+      "integrity": "sha512-6geM3CSUlXTK3n4OoKsL95M7XwKXoxiwK7cf4e/+Dj0X/ll77ihFN5j9VhLGXNYbMXDlm30kBg/VU6ymMv6o/Q==",
+      "dependencies": {
+        "@comunica/actor-dereference-fallback": "^2.0.2",
+        "@comunica/actor-dereference-file": "^2.0.2",
+        "@comunica/actor-dereference-http": "^2.0.2",
+        "@comunica/actor-dereference-rdf-parse": "^2.6.0",
+        "@comunica/actor-http-fetch": "^2.0.1",
+        "@comunica/actor-http-proxy": "^2.0.1",
+        "@comunica/actor-rdf-parse-html": "^2.0.1",
+        "@comunica/actor-rdf-parse-html-microdata": "^2.0.1",
+        "@comunica/actor-rdf-parse-html-rdfa": "^2.0.1",
+        "@comunica/actor-rdf-parse-html-script": "^2.0.1",
+        "@comunica/actor-rdf-parse-jsonld": "^2.0.1",
+        "@comunica/actor-rdf-parse-n3": "^2.0.1",
+        "@comunica/actor-rdf-parse-rdfxml": "^2.0.1",
+        "@comunica/actor-rdf-parse-shaclc": "^2.6.0",
+        "@comunica/actor-rdf-parse-xml-rdfa": "^2.0.1",
+        "@comunica/bus-dereference": "^2.0.2",
+        "@comunica/bus-dereference-rdf": "^2.0.2",
+        "@comunica/bus-http": "^2.0.1",
+        "@comunica/bus-init": "^2.0.1",
+        "@comunica/bus-rdf-parse": "^2.0.1",
+        "@comunica/bus-rdf-parse-html": "^2.0.1",
+        "@comunica/config-query-sparql": "^2.0.1",
+        "@comunica/context-entries": "^2.8.1",
+        "@comunica/core": "^2.0.1",
+        "@comunica/mediator-combine-pipeline": "^2.0.1",
+        "@comunica/mediator-combine-union": "^2.0.1",
+        "@comunica/mediator-number": "^2.0.1",
+        "@comunica/mediator-race": "^2.0.1",
+        "@rdfjs/types": "*",
+        "process": "^0.11.10",
+        "rdf-string": "^1.6.0",
+        "stream-to-string": "^1.2.0"
+      },
+      "bin": {
+        "rdf-dereference": "bin/Runner.js"
+      }
+    },
+    "node_modules/rdf-isomorphic": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/rdf-isomorphic/-/rdf-isomorphic-1.3.1.tgz",
+      "integrity": "sha512-6uIhsXTVp2AtO6f41PdnRV5xZsa0zVZQDTBdn0br+DZuFf5M/YD+T6m8hKDUnALI6nFL/IujTMLgEs20MlNidQ==",
+      "dependencies": {
+        "@rdfjs/types": "*",
+        "hash.js": "^1.1.7",
+        "rdf-string": "^1.6.0",
+        "rdf-terms": "^1.7.0"
+      }
+    },
+    "node_modules/rdf-literal": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/rdf-literal/-/rdf-literal-1.3.2.tgz",
+      "integrity": "sha512-79Stlu3sXy0kq9/decHFLf3xNPuY6sfhFPhd/diWErgaFr0Ekyg38Vh9bnVcqDYu48CFRi0t+hrFii49n92Hbw==",
+      "dependencies": {
+        "@rdfjs/types": "*",
+        "rdf-data-factory": "^1.1.0"
+      }
+    },
+    "node_modules/rdf-object": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/rdf-object/-/rdf-object-1.14.0.tgz",
+      "integrity": "sha512-/KSUWr7onDtL7d81kOpcUzJ2vHYOYJc2KU9WzBZRYydBhK0Sksh5Hg4VCQNaxUEvYEgdrrTuq9SLpOOCmag0rQ==",
+      "dependencies": {
+        "@rdfjs/types": "*",
+        "jsonld-context-parser": "^2.0.2",
+        "rdf-data-factory": "^1.1.0",
+        "rdf-string": "^1.6.0",
+        "streamify-array": "^1.0.1"
+      }
+    },
+    "node_modules/rdf-parse": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/rdf-parse/-/rdf-parse-2.3.3.tgz",
+      "integrity": "sha512-N5XEHm+ajFzwo/vVNzB4tDtvqMwBosbVJmZl5DlzplQM9ejlJBlN/43i0ImAb/NMtJJgQPC3jYnkCKGA7wdo/w==",
+      "dependencies": {
+        "@comunica/actor-http-fetch": "^2.0.1",
+        "@comunica/actor-http-proxy": "^2.0.1",
+        "@comunica/actor-rdf-parse-html": "^2.0.1",
+        "@comunica/actor-rdf-parse-html-microdata": "^2.0.1",
+        "@comunica/actor-rdf-parse-html-rdfa": "^2.0.1",
+        "@comunica/actor-rdf-parse-html-script": "^2.0.1",
+        "@comunica/actor-rdf-parse-jsonld": "^2.0.1",
+        "@comunica/actor-rdf-parse-n3": "^2.0.1",
+        "@comunica/actor-rdf-parse-rdfxml": "^2.0.1",
+        "@comunica/actor-rdf-parse-shaclc": "^2.6.2",
+        "@comunica/actor-rdf-parse-xml-rdfa": "^2.0.1",
+        "@comunica/bus-http": "^2.0.1",
+        "@comunica/bus-init": "^2.0.1",
+        "@comunica/bus-rdf-parse": "^2.0.1",
+        "@comunica/bus-rdf-parse-html": "^2.0.1",
+        "@comunica/config-query-sparql": "^2.0.1",
+        "@comunica/core": "^2.0.1",
+        "@comunica/mediator-combine-pipeline": "^2.0.1",
+        "@comunica/mediator-combine-union": "^2.0.1",
+        "@comunica/mediator-number": "^2.0.1",
+        "@comunica/mediator-race": "^2.0.1",
+        "@rdfjs/types": "*",
+        "readable-stream": "^4.3.0",
+        "stream-to-string": "^1.2.0"
+      }
+    },
+    "node_modules/rdf-quad": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/rdf-quad/-/rdf-quad-1.5.0.tgz",
+      "integrity": "sha512-LnCYx8XbRVW1wr6UiZPSy2Tv7bXAtEwuyck/68dANhFu8VMnGS+QfUNP3b9YI6p4Bfd/fyDx5E3x81IxGV6BzA==",
+      "dependencies": {
+        "rdf-data-factory": "^1.0.1",
+        "rdf-literal": "^1.2.0",
+        "rdf-string": "^1.5.0"
+      }
+    },
+    "node_modules/rdf-store-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/rdf-store-stream/-/rdf-store-stream-2.0.1.tgz",
+      "integrity": "sha512-znGaibHLvbRE0BrDcXHRleRcLKlHYP6ADr1RFJ3yA28QBmhOjxxgbBFTvCMzgsxvBIqdaFS8Vd2FG4NefJL4Mg==",
+      "dependencies": {
+        "@rdfjs/types": "*",
+        "rdf-stores": "^1.0.0"
+      }
+    },
+    "node_modules/rdf-stores": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/rdf-stores/-/rdf-stores-1.0.0.tgz",
+      "integrity": "sha512-wqp7M5409rbhpWQE0C1vyVysbz++aD2vEkZ6yueSxhDtyLvznS41R3cKiuUpm3ikc/yTpaCZwPo4iyKEaAwBIg==",
+      "dependencies": {
+        "@rdfjs/types": "*",
+        "asynciterator": "^3.8.0",
+        "rdf-data-factory": "^1.1.1",
+        "rdf-string": "^1.6.2",
+        "rdf-terms": "^1.9.1"
+      }
+    },
+    "node_modules/rdf-streaming-store": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/rdf-streaming-store/-/rdf-streaming-store-1.1.4.tgz",
+      "integrity": "sha512-Bq98GHHvmdJRTxZBH5TKYuWLAHEXiLTd/F6OeuLtWC6tQydxp7smMnYyoRtztc9p+jBsA9z9HmzQsGfEE2mj4w==",
+      "dependencies": {
+        "@rdfjs/types": "*",
+        "@types/n3": "^1.10.4",
+        "@types/readable-stream": "^2.3.15",
+        "n3": "^1.16.3",
+        "rdf-string": "^1.6.2",
+        "rdf-terms": "^1.9.1",
+        "readable-stream": "^4.3.0"
+      }
+    },
+    "node_modules/rdf-string": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/rdf-string/-/rdf-string-1.6.3.tgz",
+      "integrity": "sha512-HIVwQ2gOqf+ObsCLSUAGFZMIl3rh9uGcRf1KbM85UDhKqP+hy6qj7Vz8FKt3GA54RiThqK3mNcr66dm1LP0+6g==",
+      "dependencies": {
+        "@rdfjs/types": "*",
+        "rdf-data-factory": "^1.1.0"
+      }
+    },
+    "node_modules/rdf-string-ttl": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/rdf-string-ttl/-/rdf-string-ttl-1.3.2.tgz",
+      "integrity": "sha512-yqolaVoUvTaSC5aaQuMcB4BL54G/pCGsV4jQH87f0TvAx8zHZG0koh7XWrjva/IPGcVb1QTtaeEdfda5mcddJg==",
+      "dependencies": {
+        "@rdfjs/types": "*",
+        "rdf-data-factory": "^1.1.0"
+      }
+    },
+    "node_modules/rdf-terms": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/rdf-terms/-/rdf-terms-1.11.0.tgz",
+      "integrity": "sha512-iKlVgnMopRKl9pHVNrQrax7PtZKRCT/uJIgYqvuw1VVQb88zDvurtDr1xp0rt7N9JtKtFwUXoIQoEsjyRo20qQ==",
+      "dependencies": {
+        "@rdfjs/types": "*",
+        "rdf-data-factory": "^1.1.0",
+        "rdf-string": "^1.6.0"
+      }
+    },
+    "node_modules/rdfa-streaming-parser": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/rdfa-streaming-parser/-/rdfa-streaming-parser-2.0.1.tgz",
+      "integrity": "sha512-7Yyaj030LO7iQ38Wh/RNLVeYrVFJeyx3dpCK7C1nvX55eIN/gE4HWfbg4BYI9X7Bd+eUIUMVeiKYLmYjV6apow==",
+      "dependencies": {
+        "@rdfjs/types": "*",
+        "htmlparser2": "^8.0.0",
+        "rdf-data-factory": "^1.1.0",
+        "readable-stream": "^4.0.0",
+        "relative-to-absolute-iri": "^1.0.2"
+      }
+    },
+    "node_modules/rdfa-streaming-parser/node_modules/htmlparser2": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
+      "integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1",
+        "entities": "^4.4.0"
+      }
+    },
+    "node_modules/rdfxml-streaming-parser": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/rdfxml-streaming-parser/-/rdfxml-streaming-parser-2.4.0.tgz",
+      "integrity": "sha512-f+tdI1wxOiPzMbFWRtOwinwPsqac0WIN80668yFKcVdFCSTGOWTM70ucQGUSdDZZo7pce/UvZgV0C3LDj0P7tg==",
+      "dependencies": {
+        "@rdfjs/types": "*",
+        "@rubensworks/saxes": "^6.0.1",
+        "@types/readable-stream": "^2.3.13",
+        "buffer": "^6.0.3",
+        "rdf-data-factory": "^1.1.0",
+        "readable-stream": "^4.4.2",
+        "relative-to-absolute-iri": "^1.0.0",
+        "validate-iri": "^1.0.0"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.5.2.tgz",
+      "integrity": "sha512-yjavECdqeZ3GLXNgRXgeQEdz9fvDDkNKyHnbHRFtOr7/LcfgBcmct7t/ET+HaCTqfh06OzoAxrkN/IfjJBVe+g==",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/readable-stream-node-to-web": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/readable-stream-node-to-web/-/readable-stream-node-to-web-1.0.1.tgz",
+      "integrity": "sha512-OGzi2VKLa8H259kAx7BIwuRrXHGcxeHj4RdASSgEGBP9Q2wowdPvBc65upF4Q9O05qWgKqBw1+9PiLTtObl7uQ=="
+    },
+    "node_modules/relative-to-absolute-iri": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/relative-to-absolute-iri/-/relative-to-absolute-iri-1.0.7.tgz",
+      "integrity": "sha512-Xjyl4HmIzg2jzK/Un2gELqbcE8Fxy85A/aLSHE6PE/3+OGsFwmKVA1vRyGaz6vLWSqLDMHA+5rjD/xbibSQN1Q=="
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.4.3.tgz",
+      "integrity": "sha512-e2bDA2WJT0wxseVd4lsDP4+3ONX6HpMXQa1ZhFQ7SU+GjvORCmShbCMltrtIDfkYhVHrOcPtj+KhmDBdPdZD1g==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/semver/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="
+    },
+    "node_modules/shaclc-parse": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/shaclc-parse/-/shaclc-parse-1.4.0.tgz",
+      "integrity": "sha512-zyxjIYQH2ghg/wtMvOp+4Nr6aK8j9bqFiVT3w47K8WHPYN+S3Zgnh2ybT+dGgMwo9KjiOoywxhjC7d8Z6GCmfA==",
+      "dependencies": {
+        "@rdfjs/types": "^1.1.0",
+        "n3": "^1.16.3"
+      }
+    },
+    "node_modules/shaclc-write": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/shaclc-write/-/shaclc-write-1.4.2.tgz",
+      "integrity": "sha512-aejD8fNgTfTINInjlwW7oz4GbmIJmDFJu4Tc3WVhmMH2QV24F+Ey/I/obMP/cQu/LwcfX7O2eu7bI9RUFeDMWw==",
+      "dependencies": {
+        "@jeswr/prefixcc": "^1.2.1",
+        "n3": "^1.16.3",
+        "rdf-string-ttl": "^1.3.2"
+      }
+    },
+    "node_modules/simple-swizzle": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+      "integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
+      "dependencies": {
+        "is-arrayish": "^0.3.1"
+      }
+    },
+    "node_modules/spark-md5": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/spark-md5/-/spark-md5-3.0.2.tgz",
+      "integrity": "sha512-wcFzz9cDfbuqe0FZzfi2or1sgyIrsDwmPwfZC4hiNidPdPINjeUwNfv5kldczoEAcjl9Y1L3SM7Uz2PUEQzxQw=="
+    },
+    "node_modules/sparqlalgebrajs": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-4.3.3.tgz",
+      "integrity": "sha512-g5+fYsb+7bNDTR72cCo/BSUgTroYr3hVtf+bAz7jszx6yU8+hHZxcoDuT+zkCA3sfHs/qG9oYDD/TA3UsH07eA==",
+      "dependencies": {
+        "@rdfjs/types": "*",
+        "@types/sparqljs": "^3.1.3",
+        "fast-deep-equal": "^3.1.3",
+        "minimist": "^1.2.6",
+        "rdf-data-factory": "^1.1.0",
+        "rdf-isomorphic": "^1.3.0",
+        "rdf-string": "^1.6.0",
+        "rdf-terms": "^1.10.0",
+        "sparqljs": "^3.7.1"
+      },
+      "bin": {
+        "sparqlalgebrajs": "bin/sparqlalgebrajs.js"
+      }
+    },
+    "node_modules/sparqljs": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/sparqljs/-/sparqljs-3.7.1.tgz",
+      "integrity": "sha512-I1jYMtcwDkgCEqQ4eQuQIhB8hFAlRAJ6YDXDcV54XztaJaYRFqJlidHt77S3j8Mfh6kY6GK04dXPEIopxbEeuQ==",
+      "dependencies": {
+        "rdf-data-factory": "^1.1.2"
+      },
+      "bin": {
+        "sparqljs": "bin/sparql-to-json"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/sparqljson-parse": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/sparqljson-parse/-/sparqljson-parse-2.2.0.tgz",
+      "integrity": "sha512-2TfvNvUsaJyWfCrq3ExdDdbF9LBLzIUCricg+D1YCYbbmyTzscgCtRk4KcIyJF178DtfCt4BkKzbKl8IXMHp8w==",
+      "dependencies": {
+        "@bergos/jsonparse": "^1.4.1",
+        "@rdfjs/types": "*",
+        "@types/readable-stream": "^2.3.13",
+        "rdf-data-factory": "^1.1.0",
+        "readable-stream": "^4.0.0"
+      }
+    },
+    "node_modules/sparqljson-to-tree": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/sparqljson-to-tree/-/sparqljson-to-tree-3.0.2.tgz",
+      "integrity": "sha512-8h/ZEPPBhBlMbgMX1TOumJQku2mLYYdwd/octsDa/bdqdNcMeAcB7S2Qh4SEZ+0pPNed9CBk1d5TEUpwJlcdmw==",
+      "dependencies": {
+        "@rdfjs/types": "*",
+        "rdf-literal": "^1.3.2",
+        "sparqljson-parse": "^2.0.0"
+      }
+    },
+    "node_modules/sparqlxml-parse": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/sparqlxml-parse/-/sparqlxml-parse-2.1.1.tgz",
+      "integrity": "sha512-71sltShF6gDAzuKWEHNeij7r0Mv5VqRrvJing6W4WHJ12GRe6+t1IRTv6MeqxYN3XJmKevs7B3HCBUo7wceeJQ==",
+      "dependencies": {
+        "@rdfjs/types": "*",
+        "@rubensworks/saxes": "^6.0.1",
+        "@types/readable-stream": "^2.3.13",
+        "buffer": "^6.0.3",
+        "rdf-data-factory": "^1.1.0",
+        "readable-stream": "^4.0.0"
+      }
+    },
+    "node_modules/stack-trace": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+      "integrity": "sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/stream-to-string": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/stream-to-string/-/stream-to-string-1.2.1.tgz",
+      "integrity": "sha512-WsvTDNF8UYs369Yko3pcdTducQtYpzEZeOV7cTuReyFvOoA9S/DLJ6sYK+xPafSPHhUMpaxiljKYnT6JSFztIA==",
+      "dependencies": {
+        "promise-polyfill": "^1.1.6"
+      }
+    },
+    "node_modules/streamify-array": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/streamify-array/-/streamify-array-1.0.1.tgz",
+      "integrity": "sha512-ZnswaBcC6B1bhPLSQOlC6CdaDUSzU0wr2lvvHpbHNms8V7+DLd8uEAzDAWpsjxbFkijBHhuObFO/qqu52DZUMA=="
+    },
+    "node_modules/streamify-string": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/streamify-string/-/streamify-string-1.0.1.tgz",
+      "integrity": "sha512-RXvBglotrvSIuQQ7oC55pdV40wZ/17gTb68ipMC4LA0SqMN4Sqfsf31Dpei7qXpYqZQ8ueVnPglUvtep3tlhqw=="
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/string_decoder/node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/text-hex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
+      "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg=="
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
+    "node_modules/triple-beam": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.4.1.tgz",
+      "integrity": "sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg==",
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
+    "node_modules/undici": {
+      "version": "5.28.3",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.3.tgz",
+      "integrity": "sha512-3ItfzbrhDlINjaP0duwnNsKpDQk3acHI3gVJ1z4fmwMK31k5G9OVIAMLSIaP6w4FaGkaAkN6zaQO9LUvZ1t7VA==",
+      "dependencies": {
+        "@fastify/busboy": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
+    },
+    "node_modules/uritemplate": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/uritemplate/-/uritemplate-0.3.4.tgz",
+      "integrity": "sha512-enADBvHfhjrwxFMTVWeIIYz51SZ91uC6o2MR/NQTVljJB6HTZ8eQL3Q7JBj3RxNISA14MOwJaU3vpf5R6dyxHA=="
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+    },
+    "node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/validate-iri": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/validate-iri/-/validate-iri-1.0.1.tgz",
+      "integrity": "sha512-gLXi7351CoyVVQw8XE5sgpYawRKatxE7kj/xmCxXOZS1kMdtcqC0ILIqLuVEVnAUQSL/evOGG3eQ+8VgbdnstA=="
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/web-streams-ponyfill": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/web-streams-ponyfill/-/web-streams-ponyfill-1.4.2.tgz",
+      "integrity": "sha512-LCHW+fE2UBJ2vjhqJujqmoxh1ytEDEr0dPO3CabMdMDJPKmsaxzS90V1Ar6LtNE5VHLqxR4YMEj1i4lzMAccIA=="
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/winston": {
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-3.11.0.tgz",
+      "integrity": "sha512-L3yR6/MzZAOl0DsysUXHVjOwv8mKZ71TrA/41EIduGpOOV5LQVodqN+QdQ6BS6PJ/RdIshZhq84P/fStEZkk7g==",
+      "dependencies": {
+        "@colors/colors": "^1.6.0",
+        "@dabh/diagnostics": "^2.0.2",
+        "async": "^3.2.3",
+        "is-stream": "^2.0.0",
+        "logform": "^2.4.0",
+        "one-time": "^1.0.0",
+        "readable-stream": "^3.4.0",
+        "safe-stable-stringify": "^2.3.1",
+        "stack-trace": "0.0.x",
+        "triple-beam": "^1.3.0",
+        "winston-transport": "^4.5.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/winston-transport": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.7.0.tgz",
+      "integrity": "sha512-ajBj65K5I7denzer2IYW6+2bNIVqLGDHqDw3Ow8Ohh+vdW+rv4MZ6eiDvHoKhfJFZ2auyN8byXieDDJ96ViONg==",
+      "dependencies": {
+        "logform": "^2.3.2",
+        "readable-stream": "^3.6.0",
+        "triple-beam": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/winston-transport/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/winston/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "engines": {
+        "node": ">=12"
+      }
+    }
+  }
+}

--- a/packages/actor-init-ldes-client/package.json
+++ b/packages/actor-init-ldes-client/package.json
@@ -48,6 +48,7 @@
     "@treecg/bus-rdf-frame": "^4.0.0",
     "@treecg/types": "^0.4.0",
     "content-type": "^1.0.5",
+    "exponential-backoff": "^3.1.1",
     "http-cache-semantics": "^4.1.1",
     "js-priority-queue": "^0.1.5",
     "lru-cache": "^8.0.4",


### PR DESCRIPTION
This PR contains an attempt to take advantage of Node's built-in [backpressure in streams](https://nodejs.org/en/learn/modules/backpressuring-in-streams) (i.e. buffering in case of a slower consumer) instead of trying to manage it ourselves. It also includes an exponential backoff mechanism to retry failing requests. 

This PR should not be merged as such. We've removed some code (like for example the `paused` flag) which may be considered a breaking change (although it looks like an internal to us) and didn't extensively test all different kinds of representations. Given that a new implementation is being worked on in https://github.com/TREEcg/ldes-client, it does not seem appropriate to us to further clean up and elaborate on this PR, but we wanted to indicate what our issues have been with this client so that they can possibly be taken into account in the new implementation.

Co-author: @madnifcent